### PR TITLE
Add OCI chunked PATCH and generic JWT-bearer auth to sync

### DIFF
--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
@@ -55,15 +56,20 @@ Exit codes:
 }
 
 type syncFlags struct {
-	config      string
-	output      flags.Output
-	concurrency int
-	retries     int
-	overwrite   bool
-	dryRun      bool
-	verbose     bool
-	insecure    bool
-	noProgress  bool
+	config          string
+	output          flags.Output
+	concurrency     int
+	retries         int
+	overwrite       bool
+	dryRun          bool
+	verbose         bool
+	insecure        bool
+	noProgress      bool
+	maxChunkSize    int
+	jwtRequestURL   string
+	jwtRequestToken string
+	jwtAudience     string
+	jwtHosts        []string
 }
 
 var syncArgs = syncFlags{
@@ -90,6 +96,29 @@ func init() {
 		"Allow plaintext HTTP and skip TLS verification (test/dev only).")
 	syncCmd.Flags().BoolVar(&syncArgs.noProgress, "no-progress", false,
 		"Disable the live progress spinner.")
+	syncCmd.Flags().IntVar(&syncArgs.maxChunkSize, "oci-max-chunk-size", 0,
+		"Maximum size in KiB (1024 bytes) for an OCI blob upload PATCH; "+
+			"larger blobs are split into chunked PATCH uploads. 0 disables "+
+			"chunking (single monolithic PATCH per blob).")
+	syncCmd.Flags().StringVar(&syncArgs.jwtRequestURL, "jwt-bearer-request-url", "",
+		"Endpoint that returns a JWT given an audience query parameter. "+
+			"Must be set together with --jwt-bearer-request-token and "+
+			"--jwt-bearer-audience. When set, every registry request "+
+			"carries Authorization: Bearer <jwt>; the JWT is cached for "+
+			"the first 50%% of its remaining lifetime (read from the "+
+			"`exp` claim) and reminted on demand.")
+	syncCmd.Flags().StringVar(&syncArgs.jwtRequestToken, "jwt-bearer-request-token", "",
+		"Bearer token sent to --jwt-bearer-request-url when minting the "+
+			"registry JWT.")
+	syncCmd.Flags().StringVar(&syncArgs.jwtAudience, "jwt-bearer-audience", "",
+		"Audience claim requested from --jwt-bearer-request-url. Typically "+
+			"the destination registry hostname.")
+	syncCmd.Flags().StringSliceVar(&syncArgs.jwtHosts, "jwt-bearer-host", nil,
+		"Hostnames the JWT bearer is sent to (repeatable, also accepts a "+
+			"comma-separated list). Requests to other hosts pass through "+
+			"with their keychain auth intact, so a sync can use the bearer "+
+			"on the destination while still authenticating to the source. "+
+			"Defaults to --jwt-bearer-audience when unset.")
 
 	rootCmd.AddCommand(syncCmd)
 }
@@ -129,6 +158,11 @@ func syncCmdRun(cmd *cobra.Command, _ []string) error {
 	var clientOpts []oci.ClientOption
 	if syncArgs.insecure {
 		clientOpts = append(clientOpts, oci.Insecure())
+	}
+	if t, err := buildClientTransport(); err != nil {
+		return err
+	} else if t != nil {
+		clientOpts = append(clientOpts, oci.WithTransport(t))
 	}
 	client := oci.NewClient(clientOpts...)
 
@@ -226,6 +260,53 @@ func classifyExit(r sync.Result) error {
 	default:
 		return &syncExitError{code: r.ExitCode(), msg: ""}
 	}
+}
+
+// buildClientTransport composes the optional transport stack from
+// --oci-max-chunk-size and the --jwt-bearer-* flags. Returns (nil, nil)
+// if neither feature is requested. Stack order, outer first:
+//
+//	ChunkingTransport (split big PATCH bodies)
+//	  → JWTBearerTransport (stamp Authorization on each chunk request)
+//	    → http.DefaultTransport
+//
+// JWT is the inner wrapper so that mid-upload token refresh works
+// per chunk; chunking is the outer wrapper so split chunks each get
+// freshly stamped auth from the JWT layer.
+func buildClientTransport() (http.RoundTripper, error) {
+	var (
+		jwtSet   = syncArgs.jwtRequestURL != "" || syncArgs.jwtRequestToken != "" || syncArgs.jwtAudience != ""
+		jwtAll   = syncArgs.jwtRequestURL != "" && syncArgs.jwtRequestToken != "" && syncArgs.jwtAudience != ""
+		chunkSet = syncArgs.maxChunkSize > 0
+	)
+	if jwtSet && !jwtAll {
+		return nil, fmt.Errorf("--jwt-bearer-request-url, --jwt-bearer-request-token and --jwt-bearer-audience must all be set together (or none)")
+	}
+	if !jwtSet && !chunkSet {
+		return nil, nil
+	}
+	var t http.RoundTripper
+	t = http.DefaultTransport
+	if jwtAll {
+		hosts := syncArgs.jwtHosts
+		if len(hosts) == 0 {
+			hosts = []string{syncArgs.jwtAudience}
+		}
+		t = &oci.JWTBearerTransport{
+			Inner:        t,
+			RequestURL:   syncArgs.jwtRequestURL,
+			RequestToken: syncArgs.jwtRequestToken,
+			Audience:     syncArgs.jwtAudience,
+			Hosts:        hosts,
+		}
+	}
+	if chunkSet {
+		t = &oci.ChunkingTransport{
+			Inner:     t,
+			ChunkSize: int64(syncArgs.maxChunkSize) * 1024,
+		}
+	}
+	return t, nil
 }
 
 func resolveConfigPath() (string, error) {

--- a/internal/oci/auth.go
+++ b/internal/oci/auth.go
@@ -5,6 +5,7 @@ package oci
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -17,8 +18,9 @@ import (
 // across every Copy/Compare/List call to avoid re-resolving auth or
 // reallocating transports per tag.
 type Client struct {
-	keychain authn.Keychain
-	insecure bool
+	keychain  authn.Keychain
+	insecure  bool
+	transport http.RoundTripper
 
 	// Pre-built static option slices. The only thing varying per call is
 	// the context, which is prepended at call time. The auth keychain and
@@ -42,6 +44,13 @@ func Insecure() ClientOption {
 	return func(c *Client) { c.insecure = true }
 }
 
+// WithTransport sets the HTTP RoundTripper used for every registry call.
+// Wrap http.DefaultTransport with ChunkingTransport / JWTBearerTransport
+// (or any other RoundTripper) and pass the outermost wrapper here.
+func WithTransport(t http.RoundTripper) ClientOption {
+	return func(c *Client) { c.transport = t }
+}
+
 // NewClient returns a Client. By default it uses authn.DefaultKeychain, which
 // reads ~/.docker/config.json (or $DOCKER_CONFIG) and any configured
 // credential helpers — exactly what `docker login` and `helm registry login`
@@ -53,6 +62,10 @@ func NewClient(opts ...ClientOption) *Client {
 	}
 	c.staticCraneOpts = []crane.Option{crane.WithAuthFromKeychain(c.keychain)}
 	c.staticRemoteOpts = []remote.Option{remote.WithAuthFromKeychain(c.keychain)}
+	if c.transport != nil {
+		c.staticCraneOpts = append(c.staticCraneOpts, crane.WithTransport(c.transport))
+		c.staticRemoteOpts = append(c.staticRemoteOpts, remote.WithTransport(c.transport))
+	}
 	if c.insecure {
 		c.staticCraneOpts = append(c.staticCraneOpts, crane.Insecure)
 		c.staticNameOpts = []name.Option{name.Insecure}

--- a/internal/oci/transport.go
+++ b/internal/oci/transport.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ChunkingTransport intercepts blob-upload PATCH requests whose body
+// is larger than ChunkSize and replays them as a sequence of OCI
+// dist-spec chunked PATCHes (Content-Range: <start>-<end>). Anything
+// else passes through. The final chunk's response is returned so
+// go-containerregistry's commit step uses the correct upload Location.
+//
+// go-containerregistry sends one monolithic PATCH per blob and exposes
+// no chunking knob, so wrapping at the HTTP layer is the only seam
+// that doesn't fork the library.
+type ChunkingTransport struct {
+	Inner     http.RoundTripper
+	ChunkSize int64
+}
+
+func (t *ChunkingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.ChunkSize <= 0 ||
+		req.Method != http.MethodPatch ||
+		!isBlobUploadPath(req.URL.Path) ||
+		req.ContentLength <= 0 ||
+		req.ContentLength <= t.ChunkSize {
+		return t.Inner.RoundTrip(req)
+	}
+	return t.chunkedUpload(req)
+}
+
+func (t *ChunkingTransport) chunkedUpload(req *http.Request) (*http.Response, error) {
+	if req.Body == nil {
+		return nil, errors.New("oci.ChunkingTransport: PATCH with nil body")
+	}
+	body := req.Body
+	defer body.Close()
+
+	total := req.ContentLength
+	uploadURL := req.URL.String()
+	var lastResp *http.Response
+
+	for offset := int64(0); offset < total; {
+		remaining := total - offset
+		size := t.ChunkSize
+		if remaining < size {
+			size = remaining
+		}
+
+		// PATCH bodies need a known length and must be replayable for
+		// retries. The library hands us one reader for the original
+		// monolithic PATCH; we own framing for each chunk.
+		buf := make([]byte, size)
+		if _, err := io.ReadFull(body, buf); err != nil {
+			return nil, fmt.Errorf("read chunk at offset %d: %w", offset, err)
+		}
+
+		chunkReq, err := http.NewRequestWithContext(req.Context(), http.MethodPatch, uploadURL, bytes.NewReader(buf))
+		if err != nil {
+			return nil, err
+		}
+		copyHeader(chunkReq.Header, req.Header, "Authorization", "Content-Type", "User-Agent", "Accept")
+		if chunkReq.Header.Get("Content-Type") == "" {
+			chunkReq.Header.Set("Content-Type", "application/octet-stream")
+		}
+		chunkReq.Header.Set("Content-Range", fmt.Sprintf("%d-%d", offset, offset+size-1))
+		chunkReq.ContentLength = size
+
+		resp, err := t.Inner.RoundTrip(chunkReq)
+		if err != nil {
+			return nil, fmt.Errorf("PATCH chunk %d-%d: %w", offset, offset+size-1, err)
+		}
+		if resp.StatusCode != http.StatusAccepted {
+			return resp, nil
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if loc := resp.Header.Get("Location"); loc != "" {
+			next, err := resolveLocation(uploadURL, loc)
+			if err != nil {
+				return nil, fmt.Errorf("resolve next Location %q: %w", loc, err)
+			}
+			uploadURL = next
+		}
+		offset += size
+		lastResp = resp
+	}
+
+	if lastResp == nil {
+		return nil, errors.New("oci.ChunkingTransport: zero-length PATCH")
+	}
+	lastResp.Body = io.NopCloser(strings.NewReader(""))
+	if lastResp.Header.Get("Location") == "" {
+		lastResp.Header.Set("Location", uploadURL)
+	}
+	return lastResp, nil
+}
+
+// JWTBearerTransport stamps Authorization: Bearer <jwt> on outbound
+// requests whose URL host matches one of Hosts, where <jwt> is
+// fetched from a generic endpoint configured at construction:
+//
+//	GET  <RequestURL>?audience=<Audience>
+//	     Authorization: Bearer <RequestToken>
+//	→ {"value": "<jwt>"}
+//
+// The token is mutex-cached for the FIRST 50% of its remaining JWT
+// lifetime (read from the exp claim) and reminted on demand. Any
+// upstream Authorization header on a matched request is overwritten;
+// requests to other hosts pass through untouched (so the keychain's
+// auth for source registries still works during a sync).
+//
+// Hosts must be non-empty — pass the destination registry hostname(s)
+// the JWT is intended for. A typical setup uses Hosts = [Audience].
+type JWTBearerTransport struct {
+	Inner        http.RoundTripper
+	RequestURL   string
+	RequestToken string
+	Audience     string
+	Hosts        []string
+
+	mu    sync.Mutex
+	token string
+	exp   time.Time
+}
+
+func (t *JWTBearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.matchesHost(req.URL.Host) {
+		return t.Inner.RoundTrip(req)
+	}
+	tok, err := t.fetchToken(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("mint JWT bearer: %w", err)
+	}
+	// Don't mutate the caller's request — clone so the Authorization
+	// edit is request-scoped.
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("Authorization", "Bearer "+tok)
+	return t.Inner.RoundTrip(cloned)
+}
+
+func (t *JWTBearerTransport) matchesHost(host string) bool {
+	for _, h := range t.Hosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *JWTBearerTransport) fetchToken(ctx context.Context) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := time.Now()
+	if t.token != "" && now.Before(t.exp) {
+		return t.token, nil
+	}
+	u, err := url.Parse(t.RequestURL)
+	if err != nil {
+		return "", fmt.Errorf("parse request URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("audience", t.Audience)
+	u.RawQuery = q.Encode()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+t.RequestToken)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if out.Value == "" {
+		return "", errors.New("empty token in response")
+	}
+	exp, err := jwtExp(out.Value)
+	if err != nil {
+		return "", err
+	}
+	half := exp.Sub(now) / 2
+	if half < time.Second {
+		return "", fmt.Errorf("minted JWT already near-expired (exp=%s)", exp)
+	}
+	t.token = out.Value
+	t.exp = now.Add(half)
+	return out.Value, nil
+}
+
+// jwtExp pulls the exp claim out of a compact-serialized JWT without
+// verifying the signature — this token came from a trusted endpoint
+// one HTTP call ago and the only thing we need from it is the
+// expiration for cache scheduling.
+func jwtExp(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, errors.New("malformed JWT (expected 3 parts)")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("parse JWT claims: %w", err)
+	}
+	if claims.Exp == 0 {
+		return time.Time{}, errors.New("JWT has no exp claim")
+	}
+	return time.Unix(claims.Exp, 0).UTC(), nil
+}
+
+func isBlobUploadPath(p string) bool {
+	if !strings.HasPrefix(p, "/v2/") {
+		return false
+	}
+	return strings.Contains(p, "/blobs/uploads/")
+}
+
+func copyHeader(dst, src http.Header, keys ...string) {
+	for _, k := range keys {
+		if v := src.Get(k); v != "" {
+			dst.Set(k, v)
+		}
+	}
+}
+
+func resolveLocation(base, loc string) (string, error) {
+	b, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		return "", err
+	}
+	return b.ResolveReference(u).String(), nil
+}

--- a/internal/oci/transport_test.go
+++ b/internal/oci/transport_test.go
@@ -1,0 +1,509 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+// ---------- ChunkingTransport ----------
+
+// fakeRT records every request it sees and replies with an optional
+// per-request override; defaults to 202 Accepted with the request URL
+// echoed back as Location so the chunking loop can exercise the
+// "follow Location" path.
+type fakeRT struct {
+	calls    []recordedReq
+	override func(*http.Request) *http.Response
+}
+
+type recordedReq struct {
+	method      string
+	url         string
+	contentLen  int64
+	body        []byte
+	contentType string
+	auth        string
+	contentRng  string
+}
+
+func (f *fakeRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	f.calls = append(f.calls, recordedReq{
+		method:      req.Method,
+		url:         req.URL.String(),
+		contentLen:  req.ContentLength,
+		body:        body,
+		contentType: req.Header.Get("Content-Type"),
+		auth:        req.Header.Get("Authorization"),
+		contentRng:  req.Header.Get("Content-Range"),
+	})
+	if f.override != nil {
+		if r := f.override(req); r != nil {
+			return r, nil
+		}
+	}
+	h := http.Header{}
+	h.Set("Location", req.URL.String())
+	return &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func newPATCH(t *testing.T, url string, body []byte) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, url, strings.NewReader(string(body)))
+	NewWithT(t).Expect(err).ToNot(HaveOccurred())
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Authorization", "Bearer abc.def.ghi")
+	req.ContentLength = int64(len(body))
+	return req
+}
+
+func TestChunkingTransport_PassThrough(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		bodyLen    int
+		chunkSize  int64
+		wantChunks int
+	}{
+		{name: "chunk_size_zero", method: "PATCH", path: "/v2/repo/blobs/uploads/abc", bodyLen: 1024, chunkSize: 0, wantChunks: 1},
+		{name: "non_patch_method", method: "POST", path: "/v2/repo/blobs/uploads/abc", bodyLen: 1024, chunkSize: 100, wantChunks: 1},
+		{name: "non_blob_upload_path", method: "PATCH", path: "/v2/repo/manifests/latest", bodyLen: 1024, chunkSize: 100, wantChunks: 1},
+		{name: "body_smaller_than_chunk", method: "PATCH", path: "/v2/repo/blobs/uploads/abc", bodyLen: 50, chunkSize: 100, wantChunks: 1},
+		{name: "body_equal_to_chunk", method: "PATCH", path: "/v2/repo/blobs/uploads/abc", bodyLen: 100, chunkSize: 100, wantChunks: 1},
+		{name: "v1_path_ignored", method: "PATCH", path: "/v1/repo/blobs/uploads/abc", bodyLen: 1024, chunkSize: 100, wantChunks: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			body := make([]byte, tc.bodyLen)
+			for i := range body {
+				body[i] = byte(i)
+			}
+			fake := &fakeRT{}
+			tr := &ChunkingTransport{Inner: fake, ChunkSize: tc.chunkSize}
+			req, _ := http.NewRequest(tc.method, "https://example.test"+tc.path, strings.NewReader(string(body)))
+			req.ContentLength = int64(tc.bodyLen)
+			resp, err := tr.RoundTrip(req)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+			g.Expect(fake.calls).To(HaveLen(tc.wantChunks))
+			g.Expect(fake.calls[0].body).To(Equal(body))
+		})
+	}
+}
+
+func TestChunkingTransport_SplitsAtChunkBoundary(t *testing.T) {
+	g := NewWithT(t)
+	body := make([]byte, 250)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	fake := &fakeRT{}
+	tr := &ChunkingTransport{Inner: fake, ChunkSize: 100}
+	resp, err := tr.RoundTrip(newPATCH(t, "https://example.test/v2/repo/blobs/uploads/abc", body))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+	// Three chunks: 0-99, 100-199, 200-249.
+	g.Expect(fake.calls).To(HaveLen(3))
+	g.Expect(fake.calls[0].contentRng).To(Equal("0-99"))
+	g.Expect(fake.calls[0].contentLen).To(Equal(int64(100)))
+	g.Expect(fake.calls[0].body).To(Equal(body[:100]))
+	g.Expect(fake.calls[1].contentRng).To(Equal("100-199"))
+	g.Expect(fake.calls[1].body).To(Equal(body[100:200]))
+	g.Expect(fake.calls[2].contentRng).To(Equal("200-249"))
+	g.Expect(fake.calls[2].contentLen).To(Equal(int64(50)))
+	g.Expect(fake.calls[2].body).To(Equal(body[200:]))
+}
+
+func TestChunkingTransport_ForwardsHeaders(t *testing.T) {
+	g := NewWithT(t)
+	body := make([]byte, 200)
+	fake := &fakeRT{}
+	tr := &ChunkingTransport{Inner: fake, ChunkSize: 100}
+	_, err := tr.RoundTrip(newPATCH(t, "https://example.test/v2/repo/blobs/uploads/abc", body))
+	g.Expect(err).ToNot(HaveOccurred())
+	for _, c := range fake.calls {
+		g.Expect(c.auth).To(Equal("Bearer abc.def.ghi"))
+		g.Expect(c.contentType).To(Equal("application/octet-stream"))
+	}
+}
+
+func TestChunkingTransport_DefaultsContentType(t *testing.T) {
+	g := NewWithT(t)
+	body := make([]byte, 200)
+	fake := &fakeRT{}
+	tr := &ChunkingTransport{Inner: fake, ChunkSize: 100}
+	req, _ := http.NewRequest(http.MethodPatch, "https://example.test/v2/repo/blobs/uploads/abc", strings.NewReader(string(body)))
+	req.ContentLength = int64(len(body))
+	// No Content-Type set on caller; ChunkingTransport must default.
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(fake.calls[0].contentType).To(Equal("application/octet-stream"))
+}
+
+func TestChunkingTransport_HonorsLocationFromPriorChunk(t *testing.T) {
+	g := NewWithT(t)
+	body := make([]byte, 250)
+	var idx atomic.Int32
+	fake := &fakeRT{
+		override: func(req *http.Request) *http.Response {
+			i := int(idx.Add(1))
+			h := http.Header{}
+			// Each chunk's response sends a different Location to verify
+			// we follow it for the next chunk.
+			h.Set("Location", fmt.Sprintf("/v2/repo/blobs/uploads/session-%d", i))
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Header:     h,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}
+		},
+	}
+	tr := &ChunkingTransport{Inner: fake, ChunkSize: 100}
+	resp, err := tr.RoundTrip(newPATCH(t, "https://example.test/v2/repo/blobs/uploads/start", body))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+	// Each chunk's request URL is the prior chunk's Location, resolved
+	// against the original (absolute) upload URL.
+	g.Expect(fake.calls[0].url).To(Equal("https://example.test/v2/repo/blobs/uploads/start"))
+	g.Expect(fake.calls[1].url).To(Equal("https://example.test/v2/repo/blobs/uploads/session-1"))
+	g.Expect(fake.calls[2].url).To(Equal("https://example.test/v2/repo/blobs/uploads/session-2"))
+}
+
+func TestChunkingTransport_AbortsOnNon202(t *testing.T) {
+	g := NewWithT(t)
+	body := make([]byte, 250)
+	var idx atomic.Int32
+	fake := &fakeRT{
+		override: func(req *http.Request) *http.Response {
+			if idx.Add(1) == 2 {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Header:     http.Header{},
+					Body:       io.NopCloser(strings.NewReader("nope")),
+				}
+			}
+			h := http.Header{}
+			h.Set("Location", req.URL.String())
+			return &http.Response{StatusCode: http.StatusAccepted, Header: h, Body: io.NopCloser(strings.NewReader(""))}
+		},
+	}
+	tr := &ChunkingTransport{Inner: fake, ChunkSize: 100}
+	resp, err := tr.RoundTrip(newPATCH(t, "https://example.test/v2/repo/blobs/uploads/abc", body))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+	// Stops mid-stream — third chunk is never sent.
+	g.Expect(fake.calls).To(HaveLen(2))
+}
+
+func TestChunkingTransport_NilBody(t *testing.T) {
+	g := NewWithT(t)
+	tr := &ChunkingTransport{Inner: &fakeRT{}, ChunkSize: 100}
+	req, _ := http.NewRequest(http.MethodPatch, "https://example.test/v2/repo/blobs/uploads/abc", nil)
+	req.ContentLength = 200
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("nil body"))
+}
+
+// ---------- JWTBearerTransport ----------
+
+// makeJWT returns a compact-serialized JWT with the given exp claim.
+// Header + signature are stub bytes; the transport doesn't verify them.
+func makeJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+	enc := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+	header := enc([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, _ := json.Marshal(map[string]any{"exp": exp.Unix()})
+	return header + "." + enc(body) + "." + enc([]byte("sig"))
+}
+
+// jwtServer issues a fresh JWT with the configured TTL on each call,
+// counting requests so tests can assert cache behavior.
+type jwtServer struct {
+	server   *httptest.Server
+	calls    atomic.Int32
+	ttl      time.Duration
+	wantAuth string
+	wantAud  string
+	t        *testing.T
+}
+
+func newJWTServer(t *testing.T, ttl time.Duration) *jwtServer {
+	js := &jwtServer{ttl: ttl, wantAuth: "Bearer github-oidc-runtime-token", wantAud: "registry.example.test", t: t}
+	js.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		js.calls.Add(1)
+		g := NewWithT(t)
+		g.Expect(r.Method).To(Equal(http.MethodGet))
+		g.Expect(r.Header.Get("Authorization")).To(Equal(js.wantAuth))
+		g.Expect(r.URL.Query().Get("audience")).To(Equal(js.wantAud))
+		jwt := makeJWT(t, time.Now().Add(js.ttl))
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": jwt})
+	}))
+	t.Cleanup(js.server.Close)
+	return js
+}
+
+// recordingRT lets us assert what made it past the auth-stamping step.
+type recordingRT struct {
+	headers []string
+	hosts   []string
+}
+
+func (r *recordingRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.headers = append(r.headers, req.Header.Get("Authorization"))
+	r.hosts = append(r.hosts, req.URL.Host)
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func TestJWTBearerTransport_PassThroughOtherHosts(t *testing.T) {
+	g := NewWithT(t)
+	js := newJWTServer(t, time.Hour)
+	rec := &recordingRT{}
+	tr := &JWTBearerTransport{
+		Inner: rec, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://other.example.test/v2/", nil)
+	req.Header.Set("Authorization", "Basic abc")
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	// Untouched: did NOT mint, did NOT rewrite Authorization.
+	g.Expect(js.calls.Load()).To(Equal(int32(0)))
+	g.Expect(rec.headers).To(Equal([]string{"Basic abc"}))
+}
+
+func TestJWTBearerTransport_StampsBearerOnMatchingHost(t *testing.T) {
+	g := NewWithT(t)
+	js := newJWTServer(t, time.Hour)
+	rec := &recordingRT{}
+	tr := &JWTBearerTransport{
+		Inner: rec, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	req.Header.Set("Authorization", "Basic should-be-overwritten")
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(js.calls.Load()).To(Equal(int32(1)))
+	g.Expect(rec.headers).To(HaveLen(1))
+	g.Expect(rec.headers[0]).To(HavePrefix("Bearer "))
+	g.Expect(rec.headers[0]).ToNot(ContainSubstring("Basic"))
+}
+
+func TestJWTBearerTransport_DoesNotMutateCallerRequest(t *testing.T) {
+	g := NewWithT(t)
+	js := newJWTServer(t, time.Hour)
+	tr := &JWTBearerTransport{
+		Inner: &recordingRT{}, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	req.Header.Set("Authorization", "Basic original")
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(req.Header.Get("Authorization")).To(Equal("Basic original"))
+}
+
+func TestJWTBearerTransport_CachesTokenWithinHalfLife(t *testing.T) {
+	g := NewWithT(t)
+	js := newJWTServer(t, time.Hour)
+	rec := &recordingRT{}
+	tr := &JWTBearerTransport{
+		Inner: rec, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	for range 5 {
+		req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+		_, err := tr.RoundTrip(req)
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+	g.Expect(js.calls.Load()).To(Equal(int32(1)))
+	for _, h := range rec.headers {
+		g.Expect(h).To(Equal(rec.headers[0]))
+	}
+}
+
+func TestJWTBearerTransport_RemintsAfterHalfLifeExpiry(t *testing.T) {
+	g := NewWithT(t)
+	// 4s TTL → cache for first ~2s (well above the 1s near-expiry guard
+	// even with mint latency). Sleep 2.5s and the next call must remint.
+	js := newJWTServer(t, 4*time.Second)
+	tr := &JWTBearerTransport{
+		Inner: &recordingRT{}, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req1, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	_, err := tr.RoundTrip(req1)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(js.calls.Load()).To(Equal(int32(1)))
+
+	time.Sleep(2500 * time.Millisecond)
+
+	req2, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	_, err = tr.RoundTrip(req2)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(js.calls.Load()).To(Equal(int32(2)))
+}
+
+func TestJWTBearerTransport_ErrorsOnMintFailure(t *testing.T) {
+	g := NewWithT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	tr := &JWTBearerTransport{
+		Inner: &recordingRT{}, RequestURL: srv.URL, RequestToken: "x",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("status 403"))
+}
+
+func TestJWTBearerTransport_ErrorsOnEmptyTokenInResponse(t *testing.T) {
+	g := NewWithT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"value":""}`))
+	}))
+	t.Cleanup(srv.Close)
+	tr := &JWTBearerTransport{
+		Inner: &recordingRT{}, RequestURL: srv.URL, RequestToken: "x",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("empty token"))
+}
+
+func TestJWTBearerTransport_ErrorsOnNearExpiredJWT(t *testing.T) {
+	g := NewWithT(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// exp in 500ms → half-life 250ms → < 1s threshold → reject.
+		jwt := makeJWT(t, time.Now().Add(500*time.Millisecond))
+		_, _ = fmt.Fprintf(w, `{"value":%q}`, jwt)
+	}))
+	t.Cleanup(srv.Close)
+	tr := &JWTBearerTransport{
+		Inner: &recordingRT{}, RequestURL: srv.URL, RequestToken: "x",
+		Audience: "registry.example.test", Hosts: []string{"registry.example.test"},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.test/v2/", nil)
+	_, err := tr.RoundTrip(req)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("near-expired"))
+}
+
+func TestJWTBearerTransport_MatchesAnyOfMultipleHosts(t *testing.T) {
+	g := NewWithT(t)
+	js := newJWTServer(t, time.Hour)
+	rec := &recordingRT{}
+	tr := &JWTBearerTransport{
+		Inner: rec, RequestURL: js.server.URL, RequestToken: "github-oidc-runtime-token",
+		Audience: "registry.example.test",
+		Hosts:    []string{"registry.example.test", "alt.example.test"},
+	}
+	for _, host := range []string{"registry.example.test", "alt.example.test"} {
+		req, _ := http.NewRequest(http.MethodGet, "https://"+host+"/v2/", nil)
+		_, err := tr.RoundTrip(req)
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+	for _, h := range rec.headers {
+		g.Expect(h).To(HavePrefix("Bearer "))
+	}
+}
+
+// ---------- helpers ----------
+
+func TestJwtExp(t *testing.T) {
+	g := NewWithT(t)
+	want := time.Now().Add(2 * time.Hour).Truncate(time.Second).UTC()
+	got, err := jwtExp(makeJWT(t, want))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(Equal(want))
+
+	cases := []struct {
+		name, jwt, want string
+	}{
+		{"only_two_parts", "a.b", "expected 3 parts"},
+		{"non_base64_payload", "a.@@@.c", "decode JWT payload"},
+		{"non_json_payload", "a." + base64.RawURLEncoding.EncodeToString([]byte("not-json")) + ".c", "parse JWT claims"},
+		{"missing_exp_claim", "a." + base64.RawURLEncoding.EncodeToString([]byte(`{}`)) + ".c", "no exp claim"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := jwtExp(tc.jwt)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tc.want))
+		})
+	}
+}
+
+func TestIsBlobUploadPath(t *testing.T) {
+	g := NewWithT(t)
+	cases := map[string]bool{
+		"/v2/foo/blobs/uploads/abc":  true,
+		"/v2/foo/bar/blobs/uploads/": true,
+		"/v2/foo/blobs/sha256:abc":   false,
+		"/v2/foo/manifests/latest":   false,
+		"/v1/foo/blobs/uploads/abc":  false,
+		"/blobs/uploads/abc":         false,
+		"":                           false,
+	}
+	for path, want := range cases {
+		g.Expect(isBlobUploadPath(path)).To(Equal(want), "path %q", path)
+	}
+}
+
+func TestCopyHeader(t *testing.T) {
+	g := NewWithT(t)
+	src := http.Header{}
+	src.Set("Authorization", "Bearer x")
+	src.Set("Content-Type", "application/octet-stream")
+	src.Set("X-Skip", "yes")
+	dst := http.Header{}
+	copyHeader(dst, src, "Authorization", "Content-Type", "Missing")
+	g.Expect(dst.Get("Authorization")).To(Equal("Bearer x"))
+	g.Expect(dst.Get("Content-Type")).To(Equal("application/octet-stream"))
+	g.Expect(dst.Get("X-Skip")).To(BeEmpty())
+	g.Expect(dst.Get("Missing")).To(BeEmpty())
+}
+
+func TestResolveLocation(t *testing.T) {
+	g := NewWithT(t)
+	cases := []struct{ base, loc, want string }{
+		{"https://r.example/v2/foo/blobs/uploads/abc", "/v2/foo/blobs/uploads/xyz", "https://r.example/v2/foo/blobs/uploads/xyz"},
+		{"https://r.example/v2/foo/blobs/uploads/abc", "https://other.example/path", "https://other.example/path"},
+		{"https://r.example/v2/foo/blobs/uploads/abc", "next", "https://r.example/v2/foo/blobs/uploads/next"},
+	}
+	for _, tc := range cases {
+		got, err := resolveLocation(tc.base, tc.loc)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(Equal(tc.want))
+	}
+}


### PR DESCRIPTION
Two opt-in transport features for `flux-mirror sync`.

`--oci-max-chunk-size N` (KiB): when set, blob upload PATCH bodies larger than N KiB are split into OCI dist-spec chunked PATCHes (Content-Range). Defaults off (single monolithic PATCH per blob).

`--jwt-bearer-request-url`, `--jwt-bearer-request-token`, `--jwt-bearer-audience`: must all be set together or all unset. When set, the registry JWT is fetched from the request URL with `?audience=...`, mutex-cached for the first 50% of its remaining lifetime (read from the `exp` claim), and reminted on demand. Generic — no GH OIDC coupling.

`--jwt-bearer-host` (repeatable): hostnames the JWT is sent to. Requests to other hosts pass through with their keychain auth intact, so a sync can use the bearer on the destination while still authenticating to a separate source registry. Defaults to `--jwt-bearer-audience` when unset (typical OCI case where the audience IS the destination hostname).

Composition (outer first): ChunkingTransport → JWTBearerTransport → http.DefaultTransport. JWT is inner so each chunked PATCH gets a freshly stamped Authorization, including post-refresh.