### PR TITLE
Allow configuring drift exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,23 @@ See [`examples/`](examples) for more configurations and
 `flux-mirror sync` is designed for unattended runs. The exit code separates
 real failures from drift, so a CI gate can react to each independently:
 
-| Code | Meaning                                                                        |
-|------|--------------------------------------------------------------------------------|
-| `0`  | Clean run, every tag was copied or skipped as expected.                        |
-| `1`  | At least one tag job failed (network error, push rejected, retries exhausted). |
-| `2`  | No failures, but at least one tag drifted with `overwrite: false`.             |
+| Code | Meaning                                                                                                    |
+|------|------------------------------------------------------------------------------------------------------------|
+| `0`  | Clean run, every tag was copied or skipped as expected.                                                    |
+| `1`  | At least one tag job failed (network error, push rejected, retries exhausted).                             |
+| `2`  | No failures, but at least one tag drifted with `overwrite: false` (configurable with `--drift-exit-code`). |
 
 The `--no-progress` flag suppresses the live spinner so log output stays clean in CI:
 
 ```shell
 flux-mirror sync flux-mirror.yaml --no-progress
+```
+
+When the destination registry is known to be immutable, drift can be reported
+without failing the CI job:
+
+```shell
+flux-mirror sync flux-mirror.yaml --no-progress --drift-exit-code=0
 ```
 
 For downstream tooling, emit a structured report:

--- a/cmd/flux-mirror/main_test.go
+++ b/cmd/flux-mirror/main_test.go
@@ -50,7 +50,7 @@ func resetCmdArgs() {
 	rootCmd.SetIn(os.Stdin)
 
 	versionArgs = versionFlags{output: "text"}
-	syncArgs = syncFlags{output: "text", concurrency: 4, retries: 3}
+	syncArgs = syncFlags{output: "text", concurrency: 4, retries: 3, driftExitCode: syncDefaultDriftExitCode}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
 	// which breaks MarkFlagRequired validation in subsequent tests. Clear it

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	envConfig          = "FLUX_MIRROR_CONFIG"
-	syncDefaultTimeout = 5 * time.Minute
+	envConfig                  = "FLUX_MIRROR_CONFIG"
+	syncDefaultTimeout         = 5 * time.Minute
+	syncDefaultDriftExitCode   = 2
+	syncMaxCustomDriftExitCode = 255
 )
 
 var syncCmd = &cobra.Command{
@@ -39,7 +41,10 @@ $DOCKER_CONFIG, and configured credential helpers).
 Exit codes:
   0  clean run (everything copied/skipped as expected)
   1  at least one tag job failed
-  2  no failures, but at least one tag drifted (overwrite=false)`,
+  2  no failures, but at least one tag drifted (overwrite=false)
+
+Use --drift-exit-code=0 to keep drift-only runs green in CI when the
+destination registry is known to be immutable.`,
 	Example: `  # Run a sync against a config file
   flux-mirror sync flux-mirror.yaml
 
@@ -63,6 +68,7 @@ type syncFlags struct {
 	concurrency     int
 	retries         int
 	overwrite       bool
+	driftExitCode   int
 	dryRun          bool
 	verbose         bool
 	insecure        bool
@@ -75,9 +81,10 @@ type syncFlags struct {
 }
 
 var syncArgs = syncFlags{
-	output:      "text",
-	concurrency: 4,
-	retries:     3,
+	output:        "text",
+	concurrency:   4,
+	retries:       3,
+	driftExitCode: syncDefaultDriftExitCode,
 }
 
 func init() {
@@ -88,6 +95,8 @@ func init() {
 		"Maximum number of retry attempts per job within timeout budget.")
 	syncCmd.Flags().BoolVar(&syncArgs.overwrite, "overwrite", false,
 		"Force overwrite when the destination artifact digest has drifted")
+	syncCmd.Flags().IntVar(&syncArgs.driftExitCode, "drift-exit-code", syncArgs.driftExitCode,
+		"Exit code to use when drift is detected without failures")
 	syncCmd.Flags().BoolVar(&syncArgs.dryRun, "dry-run", false,
 		"Run the plan and comparison pipeline without performing any writes.")
 	syncCmd.Flags().BoolVar(&syncArgs.verbose, "verbose", false,
@@ -124,6 +133,10 @@ func init() {
 }
 
 func syncCmdRun(cmd *cobra.Command, args []string) error {
+	if syncArgs.driftExitCode < 0 || syncArgs.driftExitCode > syncMaxCustomDriftExitCode {
+		return fmt.Errorf("--drift-exit-code must be between 0 and %d", syncMaxCustomDriftExitCode)
+	}
+
 	cfgPath, err := resolveConfigPath(args)
 	if err != nil {
 		return err
@@ -237,7 +250,7 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return classifyExit(res)
+	return classifyExit(res, syncArgs.driftExitCode)
 }
 
 // syncExitError is returned to make `main` exit with a code other than 1
@@ -250,15 +263,19 @@ type syncExitError struct {
 func (e *syncExitError) Error() string { return e.msg }
 func (e *syncExitError) ExitCode() int { return e.code }
 
-func classifyExit(r sync.Result) error {
+func classifyExit(r sync.Result, driftExitCode int) error {
 	// Non-zero exit codes carry an empty message — failures and drift are
 	// already surfaced inline (per-failure ✗ lines) and in the Summary
 	// totals; printing a third "N failed" footer just adds noise.
-	switch r.ExitCode() {
+	code := r.ExitCode()
+	if code == syncDefaultDriftExitCode && r.HasDrift() && !r.HasFailures() {
+		code = driftExitCode
+	}
+	switch code {
 	case 0:
 		return nil
 	default:
-		return &syncExitError{code: r.ExitCode(), msg: ""}
+		return &syncExitError{code: code, msg: ""}
 	}
 }
 

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -127,6 +127,19 @@ func TestSync_DriftExitCode(t *testing.T) {
 	var ec interface{ ExitCode() int }
 	g.Expect(errors.As(err, &ec)).To(BeTrue())
 	g.Expect(ec.ExitCode()).To(Equal(2))
+
+	out, err := executeCommand([]string{"sync", cfgPath, "--insecure", "--drift-exit-code", "0"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("drifted"))
+}
+
+func TestSync_DriftExitCodeValidation(t *testing.T) {
+	g := NewWithT(t)
+	cfgPath := writeConfig(t, "ghcr.io/a/b", "ghcr.io/c/d")
+
+	_, err := executeCommand([]string{"sync", cfgPath, "--drift-exit-code", "-1"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--drift-exit-code must be between 0 and 255"))
 }
 
 func TestSync_DryRun(t *testing.T) {

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -42,6 +42,7 @@ Log in once with `docker login`, `oras login`, etc. and `flux-mirror` picks up t
 | `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel within a single config entry. Entries themselves are processed sequentially.                  |
 | `--retries N`                   | `3`     | Maximum number of retry attempts per job, bounded by `--timeout`.                                                                                  |
 | `--overwrite`                   | `false` | Force `overwrite: true` on every entry, regardless of per-entry config. See [Overwrite Behavior](./config.md#overwrite-behavior).                  |
+| `--drift-exit-code N`           | `2`     | Exit code to use when drift is detected without failures. Set to `0` for immutable destination registries that should not fail CI on drift.        |
 | `--dry-run`                     | `false` | Run the plan and comparison pipeline without performing any writes. Reported as `would-copy` / `would-overwrite` in the output.                    |
 | `--verbose`                     | `false` | Emit a structured log line per operation (entry started, mirroring tag, tag done, entry summary, sync complete) on stderr. Suppresses the spinner. |
 | `--no-progress`                 | `false` | Disable the live progress spinner. Per-job lines and the Summary still print.                                                                      |
@@ -117,7 +118,8 @@ single `✗ <entry> — plan failed: <err>` line and counted toward `failed`.
 | `2`  | No failures, but at least one tag drifted with `overwrite: false`. The destination is out of date relative to source. |
 
 Failures take precedence over drift. `--dry-run` does not bump the exit code for `would-copy` / `would-overwrite`,
-but drift detection still produces `2`.
+but drift detection still produces `2` by default. Use `--drift-exit-code=0` when the destination registry is known to be
+immutable and drift should be logged without failing CI.
 
 ## Examples
 
@@ -204,6 +206,12 @@ flux-mirror sync config.yaml --overwrite
 
 ```bash
 flux-mirror sync config.yaml --no-progress
+```
+
+For immutable destination registries, keep CI green while still logging drift:
+
+```bash
+flux-mirror sync config.yaml --no-progress --drift-exit-code=0
 ```
 
 ### Read config from stdin


### PR DESCRIPTION
Add `--drift-exit-code` so drift-only runs can exit 0 for immutable destination registries while preserving the default exit code 2.