### PR TITLE
Add Helm HTTP/S repository auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ on upstream chart repositories.
 - **Drift gating** — destination drift (different content under the same
   tag) is reported as a distinct outcome and exit code, so audit pipelines
   can differentiate "out of date" from "mutated tags".
-- **Ambient auth** — credentials come from `~/.docker/config.json` and the
-  configured credential helpers (ACR, ECR, GAR, etc.). One `docker login` covers
-  source and destination.
+- **Ambient auth** — OCI credentials come from `~/.docker/config.json` and the
+  configured credential helpers (ACR, ECR, GAR, etc.); Helm HTTP/S repository
+  credentials come from Helm's `repositories.yaml`. One `docker login` plus
+  `helm repo add` covers source and destination auth.
 - **Structured output** — `text` and `yaml`/`json` for downstream
   tooling, plus a verbose mode that streams every blob and manifest digest
   for diagnosing TLS, auth, or push failures.
@@ -66,6 +67,13 @@ Authenticate once against the destination and optionally source registries:
 
 ```shell
 docker login ghcr.io
+```
+
+For private HTTP/S Helm repositories, add or log in to the repository with Helm
+so credentials are stored in `repositories.yaml`:
+
+```shell
+helm repo add private https://charts.example.com --username "$USER" --password "$TOKEN"
 ```
 
 Write a config file describing what to mirror:

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -35,8 +35,10 @@ var syncCmd = &cobra.Command{
 	Short: "Mirror Helm charts and OCI artifacts to a destination registry",
 	Long: `Mirror Helm charts and OCI artifacts between registries based on a
 declarative YAML config (apiVersion: mirror.fluxcd.io/v1alpha1, kind: Config).
-Auth is read from the ambient Docker config (~/.docker/config.json,
-$DOCKER_CONFIG, and configured credential helpers).
+OCI registry auth is read from the ambient Docker config (~/.docker/config.json,
+$DOCKER_CONFIG, and configured credential helpers). Helm HTTP/S repository auth
+is read from Helm's default repositories.yaml path, or $HELM_REPOSITORY_CONFIG
+when set.
 
 Exit codes:
   0  clean run (everything copied/skipped as expected)

--- a/docs/config.md
+++ b/docs/config.md
@@ -151,7 +151,9 @@ idempotent.
 ### Source scheme
 
 - `http` / `https`: classic Helm repository serving `index.yaml` plus chart
-  tarballs. Assumed public; no auth fields in the YAML.
+  tarballs. Auth is loaded automatically from the ambient Helm repositories
+  config (`repositories.yaml`, or `HELM_REPOSITORY_CONFIG` when set); no auth
+  fields are needed in the flux-mirror YAML.
 - `oci`: OCI Helm registry. Each chart name is its own OCI repository at
   `<source>/<name>`. Tags whose OCI manifest is not a Helm chart (cosign
   signatures, SBOMs, other artifacts in the same repository) are filtered

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -27,12 +27,21 @@ FLUX_MIRROR_CONFIG=examples/podinfo.yaml flux-mirror sync
 
 ## Authentication
 
-Auth is read from the ambient Docker config:
+OCI registry auth is read from the ambient Docker config:
 
-- `~/.docker/config.json` (or the `DOCKER_CONFIG` env var if set).
+- `~/.docker/config.json`, or the `DOCKER_CONFIG` env var if set.
 - Any configured credential helpers (e.g., `docker-credential-osxkeychain`, `docker-credential-ecr-login`, `docker-credential-gcloud`).
 
 Log in once with `docker login`, `oras login`, etc. and `flux-mirror` picks up the credentials.
+
+Helm HTTP/S repository auth is read from the ambient Helm repositories config:
+
+- Helm's default `repositories.yaml` path, or the `HELM_REPOSITORY_CONFIG` env var if set.
+- `username` / `password`, `certFile`, `keyFile`, `caFile`, `insecure_skip_tls_verify`, and
+  `pass_credentials_all` are honored.
+
+Log in or add repositories with `helm repo add` and `flux-mirror` picks up matching HTTP/S
+repository credentials automatically.
 
 ## Flags
 

--- a/internal/helmrepo/helmrepo.go
+++ b/internal/helmrepo/helmrepo.go
@@ -10,11 +10,15 @@ package helmrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/fluxcd/flux-mirror/internal/oci"
+	"helm.sh/helm/v4/pkg/cli"
+	repo "helm.sh/helm/v4/pkg/repo/v1"
 )
 
 // Source is a Helm chart catalog backed by HTTP/S or OCI.
@@ -28,7 +32,7 @@ type Source interface {
 }
 
 // New picks the Source implementation by URL scheme:
-//   - http, https → HTTPSource (assumed public; no auth wiring per spec)
+//   - http, https → HTTPSource (auth via Helm repositories.yaml when present)
 //   - oci         → OCISource (auth via ociClient's ambient Docker config)
 func New(sourceURL string, ociClient *oci.Client) (Source, error) {
 	u, err := url.Parse(sourceURL)
@@ -37,10 +41,58 @@ func New(sourceURL string, ociClient *oci.Client) (Source, error) {
 	}
 	switch u.Scheme {
 	case "http", "https":
-		return NewHTTPSource(sourceURL), nil
+		entry, err := httpRepositoryEntry(sourceURL)
+		if err != nil {
+			return nil, err
+		}
+		return NewHTTPSourceWithEntry(sourceURL, entry)
 	case "oci":
 		return NewOCISource(strings.TrimPrefix(sourceURL, "oci://"), ociClient), nil
 	default:
 		return nil, fmt.Errorf("unsupported source scheme %q (want http, https, or oci)", u.Scheme)
 	}
+}
+
+func httpRepositoryEntry(sourceURL string) (*repo.Entry, error) {
+	settings := cli.New()
+	repos, err := repo.LoadFile(settings.RepositoryConfig)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load Helm repository config %s: %w", settings.RepositoryConfig, err)
+	}
+	sourceKey, err := normalizeRepositoryURL(sourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("normalize source URL %q: %w", sourceURL, err)
+	}
+	for _, entry := range repos.Repositories {
+		if entry == nil || strings.TrimSpace(entry.URL) == "" {
+			continue
+		}
+		entryKey, err := normalizeRepositoryURL(entry.URL)
+		if err != nil {
+			return nil, fmt.Errorf("normalize Helm repository %q URL %q: %w", entry.Name, entry.URL, err)
+		}
+		if entryKey == sourceKey {
+			entryCopy := *entry
+			return &entryCopy, nil
+		}
+	}
+	return nil, nil
+}
+
+func normalizeRepositoryURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("missing scheme or host")
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawPath = ""
+	return u.String(), nil
 }

--- a/internal/helmrepo/http.go
+++ b/internal/helmrepo/http.go
@@ -5,9 +5,12 @@ package helmrepo
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -38,6 +41,7 @@ const (
 type HTTPSource struct {
 	repoURL string
 	client  *http.Client
+	auth    *repo.Entry
 
 	once  sync.Once
 	index *repo.IndexFile
@@ -53,6 +57,23 @@ func NewHTTPSource(repoURL string) *HTTPSource {
 		repoURL: repoURL,
 		client:  &http.Client{Timeout: httpTimeout},
 	}
+}
+
+// NewHTTPSourceWithEntry constructs an HTTPSource authenticated with the
+// matching Helm repositories.yaml entry, when one exists.
+func NewHTTPSourceWithEntry(repoURL string, entry *repo.Entry) (*HTTPSource, error) {
+	src := NewHTTPSource(repoURL)
+	if entry == nil {
+		return src, nil
+	}
+	client, err := httpClientForEntry(entry)
+	if err != nil {
+		return nil, err
+	}
+	entryCopy := *entry
+	src.client = client
+	src.auth = &entryCopy
+	return src, nil
 }
 
 // ListVersions returns every version of chartName present in the repo's index.
@@ -145,6 +166,9 @@ func (s *HTTPSource) fetch(ctx context.Context, target string, maxBytes int64) (
 		return nil, fmt.Errorf("build request for %s: %w", target, err)
 	}
 	req.Header.Set("User-Agent", "flux-mirror")
+	if err := s.setAuth(req); err != nil {
+		return nil, err
+	}
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", target, err)
@@ -161,4 +185,70 @@ func (s *HTTPSource) fetch(ctx context.Context, target string, maxBytes int64) (
 		return nil, fmt.Errorf("response from %s exceeds %d bytes", target, maxBytes)
 	}
 	return data, nil
+}
+
+func (s *HTTPSource) setAuth(req *http.Request) error {
+	if s.auth == nil || s.auth.Username == "" || s.auth.Password == "" {
+		return nil
+	}
+	repoURL, err := url.Parse(s.repoURL)
+	if err != nil {
+		return fmt.Errorf("parse repository URL %q for auth: %w", s.repoURL, err)
+	}
+	if s.auth.PassCredentialsAll || (repoURL.Scheme == req.URL.Scheme && repoURL.Host == req.URL.Host) {
+		req.SetBasicAuth(s.auth.Username, s.auth.Password)
+	}
+	return nil
+}
+
+func httpClientForEntry(entry *repo.Entry) (*http.Client, error) {
+	if entry == nil || (entry.CertFile == "" && entry.KeyFile == "" && entry.CAFile == "" && !entry.InsecureSkipTLSVerify) {
+		return &http.Client{Timeout: httpTimeout}, nil
+	}
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("default HTTP transport is %T, want *http.Transport", http.DefaultTransport)
+	}
+	transport := defaultTransport.Clone()
+	tlsConfig, err := tlsConfigForEntry(entry)
+	if err != nil {
+		return nil, err
+	}
+	transport.TLSClientConfig = tlsConfig
+	return &http.Client{Timeout: httpTimeout, Transport: transport}, nil
+}
+
+func tlsConfigForEntry(entry *repo.Entry) (*tls.Config, error) {
+	cfg := &tls.Config{}
+	if entry.CertFile != "" || entry.KeyFile != "" {
+		if entry.CertFile == "" || entry.KeyFile == "" {
+			return nil, fmt.Errorf("helm repository %q must set both certFile and keyFile for client TLS", entry.Name)
+		}
+		cert, err := tls.LoadX509KeyPair(entry.CertFile, entry.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load client TLS cert/key for Helm repository %q: %w", entry.Name, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	if entry.CAFile != "" {
+		pem, err := os.ReadFile(entry.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA file for Helm repository %q: %w", entry.Name, err)
+		}
+		roots, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("load system cert pool for Helm repository %q: %w", entry.Name, err)
+		}
+		if roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("ca file for helm repository %q contains no PEM certificates", entry.Name)
+		}
+		cfg.RootCAs = roots
+	}
+	if entry.InsecureSkipTLSVerify {
+		cfg.InsecureSkipVerify = true //nolint:gosec // Mirrors Helm's explicit repository setting.
+	}
+	return cfg, nil
 }

--- a/internal/helmrepo/http_test.go
+++ b/internal/helmrepo/http_test.go
@@ -6,16 +6,25 @@ package helmrepo
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/fluxcd/pkg/helmtestserver"
 	. "github.com/onsi/gomega"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
+	repo "helm.sh/helm/v4/pkg/repo/v1"
 )
 
 const fixtureChart = "testdata/podinfo"
 
 func newHelmServer(t *testing.T, versions ...string) *helmtestserver.HelmServer {
+	t.Helper()
+	return newHelmServerWithMiddleware(t, nil, versions...)
+}
+
+func newHelmServerWithMiddleware(t *testing.T, middleware func(http.Handler) http.Handler, versions ...string) *helmtestserver.HelmServer {
 	t.Helper()
 	srv, err := helmtestserver.NewTempHelmServer()
 	if err != nil {
@@ -29,6 +38,9 @@ func newHelmServer(t *testing.T, versions ...string) *helmtestserver.HelmServer 
 	}
 	if err := srv.GenerateIndex(); err != nil {
 		t.Fatalf("generate index: %s", err)
+	}
+	if middleware != nil {
+		srv.WithMiddleware(middleware)
 	}
 	srv.Start()
 	return srv
@@ -94,4 +106,117 @@ func TestHTTPSource_IndexCachedOnce(t *testing.T) {
 	versions, err := src.ListVersions(context.Background(), "podinfo")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(versions).To(ConsistOf("0.1.0", "0.2.0"))
+}
+
+func TestHTTPSource_AuthenticatedIndexAndDownload(t *testing.T) {
+	g := NewWithT(t)
+	srv := newHelmServerWithMiddleware(t, requireBasicAuth("user", "pass"), "0.1.0", "1.2.3")
+
+	src, err := NewHTTPSourceWithEntry(srv.URL(), &repo.Entry{
+		URL:      srv.URL(),
+		Username: "user",
+		Password: "pass",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	versions, err := src.ListVersions(context.Background(), "podinfo")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(versions).To(ConsistOf("0.1.0", "1.2.3"))
+
+	tgz, err := src.Download(context.Background(), "podinfo", "1.2.3")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tgz).ToNot(BeEmpty())
+}
+
+func TestHTTPSource_DownloadPassCredentialsAll(t *testing.T) {
+	g := NewWithT(t)
+	indexSrv := newHelmServerWithMiddleware(t, requireBasicAuth("user", "pass"), "0.1.0")
+	var chartAuth []string
+	chartSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chartAuth = append(chartAuth, r.Header.Get("Authorization"))
+		http.FileServer(http.Dir(indexSrv.Root())).ServeHTTP(w, r)
+	}))
+	t.Cleanup(chartSrv.Close)
+
+	idx, err := repo.LoadIndexFile(filepath.Join(indexSrv.Root(), "index.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	idx.Entries["podinfo"][0].URLs = []string{chartSrv.URL + "/podinfo-0.1.0.tgz"}
+	g.Expect(idx.WriteFile(filepath.Join(indexSrv.Root(), "index.yaml"), 0o644)).To(Succeed())
+
+	src, err := NewHTTPSourceWithEntry(indexSrv.URL(), &repo.Entry{
+		URL:      indexSrv.URL(),
+		Username: "user",
+		Password: "pass",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = src.Download(context.Background(), "podinfo", "0.1.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(chartAuth).To(ConsistOf(""))
+
+	chartAuth = nil
+	src, err = NewHTTPSourceWithEntry(indexSrv.URL(), &repo.Entry{
+		URL:                indexSrv.URL(),
+		Username:           "user",
+		Password:           "pass",
+		PassCredentialsAll: true,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = src.Download(context.Background(), "podinfo", "0.1.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(chartAuth).To(ConsistOf("Basic dXNlcjpwYXNz"))
+}
+
+func TestNew_LoadsHelmRepositoryConfig(t *testing.T) {
+	g := NewWithT(t)
+	srv := newHelmServerWithMiddleware(t, requireBasicAuth("user", "pass"), "0.1.0")
+	reposPath := writeRepositoriesFile(t, &repo.Entry{
+		Name:     "private",
+		URL:      srv.URL() + "/",
+		Username: "user",
+		Password: "pass",
+	})
+	t.Setenv("HELM_REPOSITORY_CONFIG", reposPath)
+
+	src, err := New(srv.URL(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	versions, err := src.ListVersions(context.Background(), "podinfo")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(versions).To(ConsistOf("0.1.0"))
+}
+
+func TestNew_MissingHelmRepositoryConfigFallsBackAnonymous(t *testing.T) {
+	g := NewWithT(t)
+	srv := newHelmServer(t, "0.1.0")
+	t.Setenv("HELM_REPOSITORY_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+
+	src, err := New(srv.URL(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	versions, err := src.ListVersions(context.Background(), "podinfo")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(versions).To(ConsistOf("0.1.0"))
+}
+
+func requireBasicAuth(username, password string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotUser, gotPass, ok := r.BasicAuth()
+			if !ok || gotUser != username || gotPass != password {
+				w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeRepositoriesFile(t *testing.T, entries ...*repo.Entry) string {
+	t.Helper()
+	repos := repo.NewFile()
+	repos.Add(entries...)
+	path := filepath.Join(t.TempDir(), "repositories.yaml")
+	if err := repos.WriteFile(path, 0o600); err != nil {
+		t.Fatalf("write repositories file: %s", err)
+	}
+	return path
 }


### PR DESCRIPTION
Load matching HTTP/S Helm repository credentials from Helm's `repositories.yaml` default location or from `HELM_REPOSITORY_CONFIG` env var, including basic auth, TLS settings, and `pass_credentials_all` behavior.

Closes: #5 