### PR TITLE
Add support for shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ destination registry credentials from a `Secret` created via
 |-----------------------------|------------------------------------------------------------------|
 | `flux-mirror sync [CONFIG]` | Mirror Helm charts and OCI artifacts described by a YAML config. |
 | `flux-mirror version`       | Print the CLI version.                                           |
+| `flux-mirror completion`    | Generate shell completion for bash, fish, powershell and zsh.    |
 
 Run `flux-mirror <command> --help` for the full flag list.
 

--- a/cmd/flux-mirror/completion.go
+++ b/cmd/flux-mirror/completion.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion SHELL",
+	Short: "Generate a shell completion script",
+	Long: `Generate a shell completion script for flux-mirror.
+
+Supported shells are bash, fish, powershell, and zsh.`,
+	Example: `  # Load completions in the current bash session
+  source <(flux-mirror completion bash)
+
+  # Install zsh completions on macOS with Homebrew
+  flux-mirror completion zsh > "$(brew --prefix)/share/zsh/site-functions/_flux-mirror"
+
+  # Load completions in the current fish session
+  flux-mirror completion fish | source
+
+  # Load completions in the current PowerShell session
+  flux-mirror completion powershell | Out-String | Invoke-Expression`,
+	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	ValidArgs: []string{"bash", "fish", "powershell", "zsh"},
+	RunE:      completionCmdRun,
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+func completionCmdRun(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	switch args[0] {
+	case "bash":
+		return cmd.Root().GenBashCompletionV2(out, true)
+	case "fish":
+		return cmd.Root().GenFishCompletion(out, true)
+	case "powershell":
+		return cmd.Root().GenPowerShellCompletionWithDesc(out)
+	case "zsh":
+		return cmd.Root().GenZshCompletion(out)
+	default:
+		return fmt.Errorf("unsupported shell %q", args[0])
+	}
+}

--- a/cmd/flux-mirror/completion_test.go
+++ b/cmd/flux-mirror/completion_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCompletionCmd(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectedOutput []string
+	}{
+		{
+			name: "bash",
+			args: []string{"completion", "bash"},
+			expectedOutput: []string{
+				"bash completion V2 for flux-mirror",
+				"__flux-mirror_get_completion_results",
+			},
+		},
+		{
+			name: "fish",
+			args: []string{"completion", "fish"},
+			expectedOutput: []string{
+				"complete -c flux-mirror",
+				"__flux_mirror_perform_completion",
+			},
+		},
+		{
+			name: "powershell",
+			args: []string{"completion", "powershell"},
+			expectedOutput: []string{
+				"Register-ArgumentCompleter -CommandName 'flux-mirror'",
+				"__flux_mirrorCompleterBlock",
+			},
+		},
+		{
+			name: "zsh",
+			args: []string{"completion", "zsh"},
+			expectedOutput: []string{
+				"#compdef flux-mirror",
+				"_flux-mirror",
+			},
+		},
+		{
+			name:        "missing shell",
+			args:        []string{"completion"},
+			expectError: true,
+		},
+		{
+			name:        "unsupported shell",
+			args:        []string{"completion", "tcsh"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			output, err := executeCommand(tt.args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			for _, expected := range tt.expectedOutput {
+				g.Expect(output).To(ContainSubstring(expected))
+			}
+		})
+	}
+}
+
+func TestCompletionCmd_CompleteShells(t *testing.T) {
+	g := NewWithT(t)
+
+	output, err := executeCommand([]string{"__complete", "completion", ""})
+
+	g.Expect(err).ToNot(HaveOccurred())
+	for _, shell := range []string{"bash", "fish", "powershell", "zsh"} {
+		g.Expect(output).To(ContainSubstring(shell))
+	}
+	g.Expect(output).To(ContainSubstring(":4"))
+}


### PR DESCRIPTION
Supported shells are bash, fish, powershell, and zsh