### PR TITLE
Implement `minAge` for signature verification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,17 +13,26 @@ permissions:
 jobs:
   test-and-lint:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5050:5000
     steps:
       - name: Test suite setup
         uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@v0.10.0
         with:
           go-version: 1.26.x
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Run tests
         run: make test
       - name: Run linters
         run: make lint
       - name: Build binary
         run: make build
+      - name: Run e2e tests
+        run: make e2e
       - name: Build Docker image
         run: make docker-build
       - name: Check if working tree is dirty

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ registry-down: ## Stop the local OCI registry.
 		echo "Registry $(REGISTRY_NAME) is not running."; \
 	fi
 
+.PHONY: e2e
+e2e: ## Run the podinfo end-to-end test (requires build and registry-up).
+	./test/podinfo.sh
+
 .PHONY: install
 install: test lint build ## Test, lint, build and copy the binary to GOBIN.
 	cp bin/flux-mirror $(GOBIN)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ on upstream chart repositories.
   drift detection on re-runs is content-based and stable.
 - **OCI 1.1 referrers** — opt-in mirror of signatures, SBOMs, and attestations attached to artifacts.
 - **Cosign verification** — opt-in keyless signature verification for selected
-  source artifacts before they are mirrored.
+  source artifacts before they are mirrored, with optional minimum signature age.
 - **Selector pipeline** — for OCI artifacts, a four-step
   `regex → semver → sort → top-N` filter. For charts, a semver constraint
   plus top-N. Sort by `semver`, `alphabetical`, or `numerical`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,6 +18,7 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
+      minAge: 48h
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/stefanprodan/.*$
@@ -202,15 +203,21 @@ mirrored. Verification uses Cosign v3 bundles attached to the source
 artifact as OCI referrers. If any selected tag has no matching valid signature,
 planning fails for that artifact entry and no copy job is scheduled for it.
 
-| Field               | Type   | Description                                                                 |
-|---------------------|--------|-----------------------------------------------------------------------------|
-| `provider`          | string | Must be `cosign`.                                                           |
-| `matchOIDCIdentity` | list   | One or more OIDC identity matchers accepted for the signing certificate.    |
-| `issuer`            | string | OIDC issuer URL, e.g. `https://token.actions.githubusercontent.com`.        |
-| `subject`           | string | Go regexp matched against the signing certificate subject alternative name. |
+| Field               | Type     | Description                                                                                                 |
+|---------------------|----------|-------------------------------------------------------------------------------------------------------------|
+| `provider`          | string   | Must be `cosign`.                                                                                           |
+| `minAge`            | duration | Optional minimum age since the verified Rekor integrated timestamp. Tags with newer signatures are skipped. |
+| `matchOIDCIdentity` | list     | One or more OIDC identity matchers accepted for the signing certificate.                                    |
+| `issuer`            | string   | OIDC issuer URL, e.g. `https://token.actions.githubusercontent.com`.                                        |
+| `subject`           | string   | Go regexp matched against the signing certificate subject alternative name.                                 |
 
 Multiple `matchOIDCIdentity` entries are treated as alternatives; a signature
 is accepted when any identity matches.
+
+When `minAge` is set, the signature must contain a verified transparency-log
+integrated timestamp old enough to satisfy the duration. Tags with valid but
+too-recent signatures are reported as `skipped` and are not copied; signatures
+without an enforceable verified integrated timestamp fail verification.
 
 ```yaml
 artifacts:
@@ -222,6 +229,7 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
+      minAge: 168h # 7 days old
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/stefanprodan/.*$
@@ -341,6 +349,7 @@ that exist with a different digest are skipped (default) or replaced
 | `artifacts[].overwrite`        | `false`  |
 | `artifacts[].includeReferrers` | `false`  |
 | `artifacts[].verify`           | unset    |
+| `artifacts[].verify.minAge`    | unset    |
 | `charts[].version`             | `*`      |
 | `charts[].limit`               | `1`      |
 | `charts[].overwrite`           | `false`  |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -109,14 +109,14 @@ flux-mirror sync config.yaml -o json | jq '.entries[].outcomes.copied'
 
 Each tag job lands in exactly one of these buckets:
 
-| Outcome           | Meaning                                                                                       |
-|-------------------|-----------------------------------------------------------------------------------------------|
-| `copied`          | Destination did not have the tag; mirrored from source.                                       |
-| `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                   |
-| `skipped`         | Destination already had the same digest; nothing to do.                                       |
-| `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary. |
-| `would-copy`      | Dry-run forecast: would have been copied.                                                     |
-| `would-overwrite` | Dry-run forecast: would have been overwritten.                                                |
+| Outcome           | Meaning                                                                                           |
+|-------------------|---------------------------------------------------------------------------------------------------|
+| `copied`          | Destination did not have the tag; mirrored from source.                                           |
+| `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                       |
+| `skipped`         | Nothing was copied: destination already matched, or `verify.minAge` deferred a too-new signature. |
+| `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary.     |
+| `would-copy`      | Dry-run forecast: would have been copied.                                                         |
+| `would-overwrite` | Dry-run forecast: would have been overwritten.                                                    |
 
 Plan-time failures (e.g., source registry rejected a `ListTags`, or cosign
 verification failed for a selected source tag) are reported as a single
@@ -158,6 +158,7 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
+      minAge: 48h
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/stefanprodan/.*$

--- a/examples/artifacts.yaml
+++ b/examples/artifacts.yaml
@@ -24,6 +24,7 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
+      minAge: 24h
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/stefanprodan/.*$

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/api v0.36.1
+	k8s.io/apimachinery v0.36.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -201,7 +202,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
-	k8s.io/apimachinery v0.36.1 // indirect
 	k8s.io/apiserver v0.36.0 // indirect
 	k8s.io/cli-runtime v0.36.0 // indirect
 	k8s.io/client-go v0.36.0 // indirect

--- a/internal/artifacts/mirror.go
+++ b/internal/artifacts/mirror.go
@@ -5,6 +5,7 @@ package artifacts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -102,6 +103,22 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 
 		if m.entry.Verify != nil {
 			if err := m.opts.Verifier.Verify(ctx, job.src, *m.entry.Verify); err != nil {
+				var tooNew *oci.SignatureTooNewError
+				if errors.As(err, &tooNew) {
+					m.opts.Logger.Info("signature too new; skipping tag",
+						"src", job.src,
+						"integrated_time", tooNew.IntegratedTime.Format(time.RFC3339),
+						"age", tooNew.Age.Round(time.Second),
+						"min_age", tooNew.MinAge)
+					plan.Jobs = append(plan.Jobs, sync.Job{
+						ID:  tag,
+						Dst: job.dst,
+						Run: func(context.Context) (sync.Outcome, error) {
+							return sync.OutcomeSkipped, nil
+						},
+					})
+					continue
+				}
 				return plan, fmt.Errorf("verify %s: %w", job.src, err)
 			}
 		}

--- a/internal/artifacts/mirror_test.go
+++ b/internal/artifacts/mirror_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/flux-mirror/internal/config"
 	"github.com/fluxcd/flux-mirror/internal/oci"
@@ -151,6 +152,48 @@ func TestMirror_VerificationFailureStopsPlanning(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("verify " + src + ":1.0.0"))
 	g.Expect(err.Error()).To(ContainSubstring("denied"))
 	g.Expect(plan.Jobs).To(BeEmpty())
+}
+
+func TestMirror_SkipsSignatureTooNew(t *testing.T) {
+	g := NewWithT(t)
+	src := repo("verify-young-src")
+	dst := repo("verify-young-dst")
+
+	testregistry.PushImage(t, src+":1.0.0")
+
+	c := oci.NewClient(oci.Insecure())
+	entry := config.ArtifactEntry{
+		Source:      src,
+		Destination: dst,
+		Selector:    config.Selector{Limit: new(1)},
+		Verify: &config.ArtifactVerification{
+			Provider: config.VerifyProviderCosign,
+			MinAge:   &metav1.Duration{Duration: time.Hour},
+			MatchOIDCIdentity: []config.OIDCIdentity{{
+				Issuer:  "https://token.actions.githubusercontent.com",
+				Subject: `^https://github\.com/example/.*$`,
+			}},
+		},
+		IncludeReferrers: true,
+	}
+	verifier := &recordingVerifier{err: &oci.SignatureTooNewError{
+		IntegratedTime: time.Now().Add(-30 * time.Minute),
+		Age:            30 * time.Minute,
+		MinAge:         time.Hour,
+	}}
+	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
+		New(c, entry, Options{
+			Verifier: verifier,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.HasFailures()).To(BeFalse())
+	g.Expect(res.Entries[0].Outcomes[sync.OutcomeSkipped]).To(Equal([]string{"1.0.0"}))
+	g.Expect(verifier.refs).To(Equal([]string{src + ":1.0.0"}))
+
+	_, err = crane.Digest(dst+":1.0.0", crane.Insecure)
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestMirror_SkipsEqual(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/name"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -129,8 +130,9 @@ type ArtifactEntry struct {
 
 // ArtifactVerification configures signature verification for source artifacts.
 type ArtifactVerification struct {
-	Provider          string         `json:"provider"`
-	MatchOIDCIdentity []OIDCIdentity `json:"matchOIDCIdentity,omitempty"`
+	Provider          string           `json:"provider"`
+	MatchOIDCIdentity []OIDCIdentity   `json:"matchOIDCIdentity,omitempty"`
+	MinAge            *metav1.Duration `json:"minAge,omitempty"`
 }
 
 // OIDCIdentity matches a Fulcio certificate identity.
@@ -356,6 +358,9 @@ func (v ArtifactVerification) validate() error {
 	}
 	if len(v.MatchOIDCIdentity) == 0 {
 		return fmt.Errorf("matchOIDCIdentity must contain at least one identity")
+	}
+	if v.MinAge != nil && v.MinAge.Duration < 0 {
+		return fmt.Errorf("minAge must be >= 0")
 	}
 	for i, id := range v.MatchOIDCIdentity {
 		if strings.TrimSpace(id.Issuer) == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,8 +6,10 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDecode_FullExample(t *testing.T) {
@@ -31,6 +33,7 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
+      minAge: 12h
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/dexidp/.*$
@@ -54,6 +57,8 @@ artifacts:
 	g.Expect(cfg.Artifacts).To(HaveLen(2))
 	g.Expect(cfg.Artifacts[0].IncludeReferrers).To(BeTrue())
 	g.Expect(cfg.Artifacts[0].Verify.Provider).To(Equal(VerifyProviderCosign))
+	g.Expect(cfg.Artifacts[0].Verify.MinAge).ToNot(BeNil())
+	g.Expect(cfg.Artifacts[0].Verify.MinAge.Duration).To(Equal(12 * time.Hour))
 	g.Expect(cfg.Artifacts[0].Verify.MatchOIDCIdentity).To(Equal([]OIDCIdentity{{
 		Issuer:  "https://token.actions.githubusercontent.com",
 		Subject: `^https://github\.com/dexidp/.*$`,
@@ -337,6 +342,21 @@ func TestValidate_Table(t *testing.T) {
 				}}}}},
 			errMsg: "aud can only be set with jwkPath or provider",
 		},
+		{
+			name: "verify negative minAge",
+			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: []ArtifactEntry{{
+				Source: "ghcr.io/a/b", Destination: "ghcr.io/c/d",
+				Verify: &ArtifactVerification{
+					Provider: VerifyProviderCosign,
+					MinAge:   &metav1.Duration{Duration: -time.Second},
+					MatchOIDCIdentity: []OIDCIdentity{{
+						Issuer:  "https://token.actions.githubusercontent.com",
+						Subject: `^https://github\.com/a/.*$`,
+					}},
+				},
+			}}},
+			errMsg: "minAge must be >= 0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -364,4 +384,23 @@ func TestDecode_BadYAML(t *testing.T) {
 	_, err := Decode(strings.NewReader("apiVersion: [oops"))
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("parse config"))
+}
+
+func TestDecode_BadDuration(t *testing.T) {
+	g := NewWithT(t)
+	_, err := Decode(strings.NewReader(`
+apiVersion: mirror.fluxcd.io/v1alpha1
+kind: Config
+artifacts:
+  - source: ghcr.io/a/b
+    destination: ghcr.io/c/d
+    verify:
+      provider: cosign
+      minAge: soon
+      matchOIDCIdentity:
+        - issuer: https://token.actions.githubusercontent.com
+          subject: ^https://github\.com/a/.*$
+`))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("invalid duration"))
 }

--- a/internal/oci/verify.go
+++ b/internal/oci/verify.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -26,6 +27,21 @@ const (
 	minBundleVersion              = "v0.3"
 	sigstoreBundleMediaTypePrefix = "application/vnd.dev.sigstore.bundle"
 )
+
+// SignatureTooNewError reports a valid signature that has not aged past the
+// configured minimum transparency-log integration age.
+type SignatureTooNewError struct {
+	IntegratedTime time.Time
+	Age            time.Duration
+	MinAge         time.Duration
+}
+
+func (e *SignatureTooNewError) Error() string {
+	return fmt.Sprintf("signature age (%s) is less than the required minAge (%s); signature was integrated at %s",
+		e.Age.Round(time.Second),
+		e.MinAge,
+		e.IntegratedTime.Format(time.RFC3339))
+}
 
 // Verifier verifies cosign keyless signatures stored as OCI referrers.
 type Verifier struct {
@@ -115,8 +131,41 @@ func (v *Verifier) Verify(ctx context.Context, ref string, cfg config.ArtifactVe
 		verify.WithArtifactDigest(desc.Digest.Algorithm, digestBytes),
 		policyOptions...,
 	)
-	if _, err := sigVerifier.Verify(&b, policy); err != nil {
+	result, err := sigVerifier.Verify(&b, policy)
+	if err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
+	}
+	if cfg.MinAge != nil && cfg.MinAge.Duration > 0 {
+		if err := enforceMinAge(result, cfg.MinAge.Duration, time.Now()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func enforceMinAge(result *verify.VerificationResult, minAge time.Duration, now time.Time) error {
+	var signatureTime time.Time
+	for _, ts := range result.VerifiedTimestamps {
+		if ts.Type != "Tlog" || ts.Timestamp.IsZero() {
+			continue
+		}
+		if signatureTime.IsZero() || ts.Timestamp.Before(signatureTime) {
+			signatureTime = ts.Timestamp
+		}
+	}
+	if signatureTime.IsZero() {
+		return fmt.Errorf("cannot enforce minAge: no verified transparency log integrated timestamps found in signature bundle")
+	}
+	signatureAge := now.Sub(signatureTime)
+	if signatureAge < 0 {
+		signatureAge = 0
+	}
+	if signatureAge < minAge {
+		return &SignatureTooNewError{
+			IntegratedTime: signatureTime,
+			Age:            signatureAge,
+			MinAge:         minAge,
+		}
 	}
 	return nil
 }

--- a/internal/oci/verify_test.go
+++ b/internal/oci/verify_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	sigverify "github.com/sigstore/sigstore-go/pkg/verify"
+)
+
+func TestEnforceMinAge(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		result    *sigverify.VerificationResult
+		minAge    time.Duration
+		wantErr   string
+		wantYoung bool
+	}{
+		{
+			name: "old enough",
+			result: &sigverify.VerificationResult{VerifiedTimestamps: []sigverify.TimestampVerificationResult{{
+				Type:      "Tlog",
+				Timestamp: now.Add(-2 * time.Hour),
+			}}},
+			minAge: time.Hour,
+		},
+		{
+			name: "uses oldest verified tlog timestamp",
+			result: &sigverify.VerificationResult{VerifiedTimestamps: []sigverify.TimestampVerificationResult{
+				{Type: "Tlog", Timestamp: now.Add(-30 * time.Minute)},
+				{Type: "Tlog", Timestamp: now.Add(-2 * time.Hour)},
+			}},
+			minAge: time.Hour,
+		},
+		{
+			name: "too new",
+			result: &sigverify.VerificationResult{VerifiedTimestamps: []sigverify.TimestampVerificationResult{{
+				Type:      "Tlog",
+				Timestamp: now.Add(-30 * time.Minute),
+			}}},
+			minAge:    time.Hour,
+			wantErr:   "signature age (30m0s) is less than the required minAge (1h0m0s)",
+			wantYoung: true,
+		},
+		{
+			name: "no tlog timestamp",
+			result: &sigverify.VerificationResult{VerifiedTimestamps: []sigverify.TimestampVerificationResult{{
+				Type:      "TimestampAuthority",
+				Timestamp: now.Add(-2 * time.Hour),
+			}}},
+			minAge:  time.Hour,
+			wantErr: "no verified transparency log integrated timestamps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := enforceMinAge(tt.result, tt.minAge, now)
+			if tt.wantErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+				return
+			}
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
+			var young *SignatureTooNewError
+			g.Expect(errors.As(err, &young)).To(Equal(tt.wantYoung))
+		})
+	}
+}

--- a/internal/sync/entry.go
+++ b/internal/sync/entry.go
@@ -50,7 +50,7 @@ type Outcome string
 const (
 	OutcomeCopied         Outcome = "copied"
 	OutcomeOverwritten    Outcome = "overwritten"
-	OutcomeSkipped        Outcome = "skipped" // dst already had the same digest
+	OutcomeSkipped        Outcome = "skipped" // nothing was copied
 	OutcomeDrifted        Outcome = "drifted" // dst had a different digest, overwrite=false
 	OutcomeWouldCopy      Outcome = "would-copy"
 	OutcomeWouldOverwrite Outcome = "would-overwrite"

--- a/test/podinfo.sh
+++ b/test/podinfo.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Flux Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# End-to-end test for the podinfo mirror config.
+# Prerequisites: a local OCI registry on port 5050 (make registry-up)
+# and the binary built at ./bin/flux-mirror (make build).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO_ROOT}/bin/flux-mirror"
+CONFIG="${REPO_ROOT}/test/podinfo.yaml"
+REGISTRY="localhost:5050"
+
+if [[ ! -x "${BIN}" ]]; then
+  echo "FAIL: binary not found at ${BIN}, run 'make build'" >&2
+  exit 1
+fi
+
+echo "==> Running sync"
+"${BIN}" sync "${CONFIG}" --insecure --verbose
+
+echo ""
+echo "==> Verifying Helm charts (mediaType)"
+HELM_MEDIA_TYPE="application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+for tag in 6.11.2 6.11.1; do
+  echo -n "  charts/podinfo:${tag} ... "
+  MANIFEST=$(docker manifest inspect "${REGISTRY}/charts/podinfo:${tag}" --insecure)
+  MATCH=$(echo "${MANIFEST}" | jq -r --arg mt "${HELM_MEDIA_TYPE}" '[.layers[] | select(.mediaType == $mt)] | length')
+  if [[ "${MATCH}" -eq 0 ]]; then
+    echo "FAIL (no ${HELM_MEDIA_TYPE} layer)" >&2
+    echo "${MANIFEST}" | jq . >&2
+    exit 1
+  fi
+  echo "OK"
+done
+
+echo ""
+echo "==> Verifying OCI manifests (mediaType)"
+FLUX_MEDIA_TYPE="application/vnd.cncf.flux.content.v1.tar+gzip"
+for tag in 6.11.2 6.11.1; do
+  echo -n "  manifests/podinfo:${tag} ... "
+  MANIFEST=$(docker manifest inspect "${REGISTRY}/manifests/podinfo:${tag}" --insecure)
+  MATCH=$(echo "${MANIFEST}" | jq -r --arg mt "${FLUX_MEDIA_TYPE}" '[.layers[] | select(.mediaType == $mt)] | length')
+  if [[ "${MATCH}" -eq 0 ]]; then
+    echo "FAIL (no ${FLUX_MEDIA_TYPE} layer)" >&2
+    echo "${MANIFEST}" | jq . >&2
+    exit 1
+  fi
+  echo "OK"
+done
+
+echo ""
+echo "==> Verifying container images (cosign)"
+for tag in 6.11.2 6.11.1; do
+  echo -n "  podinfo:${tag} ... "
+  if ! COSIGN_OUT=$(cosign verify "${REGISTRY}/podinfo:${tag}" \
+    --certificate-identity-regexp '^https://github\.com/stefanprodan/.*$' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --allow-http-registry 2>&1); then
+    echo "FAIL" >&2
+    echo "${COSIGN_OUT}" >&2
+    exit 1
+  fi
+  echo "OK"
+done
+
+echo ""
+echo "==> Re-running sync (idempotency check)"
+SYNC_OUT=$("${BIN}" sync "${CONFIG}" --insecure -o json)
+
+NON_SKIPPED=$(echo "${SYNC_OUT}" | jq '[.entries[] | .outcomes | to_entries[] | select(.key != "skipped")] | length')
+if [[ "${NON_SKIPPED}" -ne 0 ]]; then
+  echo "FAIL: expected all outcomes to be skipped on re-sync" >&2
+  echo "${SYNC_OUT}" | jq . >&2
+  exit 1
+fi
+
+SKIPPED=$(echo "${SYNC_OUT}" | jq '[.entries[].outcomes.skipped[]] | length')
+echo "  all ${SKIPPED} tags skipped"
+
+echo ""
+echo "PASS: all artifacts verified"

--- a/test/podinfo.yaml
+++ b/test/podinfo.yaml
@@ -1,0 +1,38 @@
+apiVersion: mirror.fluxcd.io/v1alpha1
+kind: Config
+charts:
+  - name: podinfo
+    source: https://stefanprodan.github.io/podinfo
+    destination: oci://localhost:5050/charts
+    version: "6.11.x"
+    limit: 2
+artifacts:
+  - source: ghcr.io/stefanprodan/manifests/podinfo
+    destination: localhost:5050/manifests/podinfo
+    selector:
+      regex:
+        pattern: '^6\.11\.(?P<patch>\d+)$'
+        extract: "${patch}"
+      sortBy: numerical
+      limit: 2
+    includeReferrers: true
+    overwrite: true
+    verify:
+      provider: cosign
+      minAge: 48h
+      matchOIDCIdentity:
+        - issuer: https://token.actions.githubusercontent.com
+          subject: ^https://github\.com/stefanprodan/.*$
+  - source: ghcr.io/stefanprodan/podinfo
+    destination: localhost:5050/podinfo
+    selector:
+      semver: "6.11.x"
+      limit: 2
+    includeReferrers: true
+    overwrite: false
+    verify:
+      provider: cosign
+      minAge: 48h
+      matchOIDCIdentity:
+        - issuer: https://token.actions.githubusercontent.com
+          subject: ^https://github\.com/stefanprodan/.*$


### PR DESCRIPTION
When `verify.minAge` is set, the signature must contain a verified transparency-log integrated timestamp old enough to satisfy the duration. Tags with valid but too-recent signatures are reported as `skipped` and are not copied. Signatures without an enforceable verified integrated timestamp fail verification.

Example for mirroring images older than 7 days:

```yaml
apiVersion: mirror.fluxcd.io/v1alpha1
kind: Config
artifacts:
  - source: ghcr.io/stefanprodan/podinfo
    destination: quay.io/my-org/podinfo
    selector:
      semver: "*"
      limit: 1
    includeReferrers: true
    verify:
      provider: cosign
      minAge: 168h # 7 days old
      matchOIDCIdentity:
        - issuer: https://token.actions.githubusercontent.com
          subject: ^https://github\.com/stefanprodan/.*$
``` 

Closes: https://github.com/fluxcd/source-controller/pull/2060