### PR TITLE
Introduce credential from cloud providers

### DIFF
--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -4,17 +4,30 @@
 package main
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	craneLogs "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/spf13/cobra"
+	"google.golang.org/api/idtoken"
 
+	"github.com/fluxcd/pkg/auth/actionsoidc"
 	"github.com/fluxcd/pkg/auth/utils/cijwt"
 
 	"github.com/fluxcd/flux-mirror/internal/artifacts"
@@ -302,20 +315,25 @@ func buildClientTransport(auth *config.Auth) (http.RoundTripper, error) {
 }
 
 // jwtTransportOptions turns the validated auth.hosts config into cijwt options,
-// reading FromEnv environment variables and JWKPath files at this point.
-// FromPath is wired straight to cijwt, which re-reads the file on every
-// request. It assumes the config has passed config validation (exactly one
-// source per host and the required fields present), so it only reports errors
-// that need runtime state: an unset env var or an unreadable key file.
+// reading FromEnv environment variables and JWKPath files at this point and
+// wiring each Provider to its token-minting closure. FromPath is wired straight
+// to cijwt, which re-reads the file on every request. It assumes the config
+// has passed config validation (exactly one source per host and the required
+// fields present), so it only reports errors that need runtime state: an unset
+// env var or an unreadable key file.
 func jwtTransportOptions(inner http.RoundTripper, auth *config.Auth) ([]cijwt.Option, error) {
 	opts := []cijwt.Option{cijwt.WithInner(inner)}
 
 	for _, h := range auth.Hosts {
-		j := h.JWT
+		j := h.Credential
 		aud := h.EffectiveAud()
 		switch {
 		case j.Provider != "":
-			opts = append(opts, cijwt.WithHostAudience(h.Host, aud))
+			fn, err := providerTokenFunc(j.Provider, aud)
+			if err != nil {
+				return nil, fmt.Errorf("auth host %q: %w", h.Host, err)
+			}
+			opts = append(opts, cijwt.WithHostTokenFunc(h.Host, fn))
 		case j.FromEnv != "":
 			token := os.Getenv(j.FromEnv)
 			if token == "" {
@@ -334,6 +352,140 @@ func jwtTransportOptions(inner http.RoundTripper, auth *config.Auth) ([]cijwt.Op
 	}
 
 	return opts, nil
+}
+
+// providerTokenFunc returns a cijwt.TokenFunc that mints a per-request bearer
+// credential for aud using the given provider: an OIDC ID/access token for the
+// OIDC providers, or a signed sts:GetCallerIdentity envelope for aws. cijwt
+// parses each returned token's exp claim and caches it for the first 50% of its
+// lifetime, so the closure runs only on a cache miss and any ctx-scoped setup
+// happens lazily under the request's own context.
+func providerTokenFunc(provider, aud string) (cijwt.TokenFunc, error) {
+	switch provider {
+	case config.JWTProviderGitHub, config.JWTProviderForgejo:
+		return func(ctx context.Context) (string, error) {
+			return actionsoidc.FetchToken(ctx, aud)
+		}, nil
+	case config.JWTProviderGCP:
+		return func(ctx context.Context) (string, error) {
+			ts, err := idtoken.NewTokenSource(ctx, aud)
+			if err != nil {
+				return "", fmt.Errorf("create GCP ID token source: %w", err)
+			}
+			tok, err := ts.Token()
+			if err != nil {
+				return "", err
+			}
+			return tok.AccessToken, nil
+		}, nil
+	case config.JWTProviderAzure:
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("create Azure credential: %w", err)
+		}
+		// aud must be the App ID URI (or client ID) of a registered Entra
+		// application configured for v2 access tokens; the .default suffix
+		// requests a token whose aud claim is that application, signed by
+		// Entra and verifiable through its OIDC discovery document.
+		scopes := []string{aud + "/.default"}
+		return func(ctx context.Context) (string, error) {
+			tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: scopes})
+			if err != nil {
+				return "", err
+			}
+			return tok.Token, nil
+		}, nil
+	case config.JWTProviderAWS:
+		signer := v4.NewSigner()
+		return func(ctx context.Context) (string, error) {
+			cfg, err := awsconfig.LoadDefaultConfig(ctx)
+			if err != nil {
+				return "", fmt.Errorf("load AWS config: %w", err)
+			}
+			region := cfg.Region
+			if region == "" {
+				region = "us-east-1"
+			}
+			return mintAWSSTSToken(ctx, cfg.Credentials, signer, region, aud)
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q", provider)
+	}
+}
+
+// awsSTSTokenTTL bounds how long flux-mirror reuses a signed GetCallerIdentity
+// request before re-signing. cijwt re-mints at 50% of this, so a given signed
+// request is replayed for at most half of it — kept well inside the few-minute
+// window AWS STS accepts a SigV4 request's timestamp.
+const awsSTSTokenTTL = 2 * time.Minute
+
+// awsAudienceHeader carries aud, signed into the GetCallerIdentity request to
+// pin the intended registry, so a request minted for one host cannot be
+// replayed against another. The registry must require it and match it to its
+// own identity. It plays the role Vault's X-Vault-AWS-IAM-Server-ID guard does.
+const awsAudienceHeader = "X-Audience"
+
+// awsSTSTokenType is the JOSE "typ" header the registry uses to tell this
+// envelope apart from a real OIDC JWT. Together with "alg":"none" it signals
+// "do not validate me as a JWT — replay my sts claim to STS instead". The
+// registry must route on this and must never trust the envelope's claims; the
+// only source of identity is the STS response, which sidesteps the classic
+// alg=none confusion attack.
+const awsSTSTokenType = "aws-sigv4-getcalleridentity"
+
+// mintAWSSTSToken builds a SigV4-signed sts:GetCallerIdentity request and wraps
+// it in a JWT-shaped envelope. AWS issues no JWT of its own, so the registry
+// verifies identity out-of-band: it replays the signed request to STS (which
+// validates the signature) and reads the returned account/ARN. The envelope is
+// not a real JWT — it carries the signed request under the "sts" claim and an
+// unverified exp that only tells the cijwt transport when to re-mint; nothing
+// checks its (empty) signature segment.
+func mintAWSSTSToken(ctx context.Context, creds aws.CredentialsProvider, signer *v4.Signer, region, serverID string) (string, error) {
+	c, err := creds.Retrieve(ctx)
+	if err != nil {
+		return "", fmt.Errorf("retrieve AWS credentials: %w", err)
+	}
+
+	const body = "Action=GetCallerIdentity&Version=2011-06-15"
+	url := fmt.Sprintf("https://sts.%s.amazonaws.com/", region)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(awsAudienceHeader, serverID)
+
+	sum := sha256.Sum256([]byte(body))
+	now := time.Now()
+	if err := signer.SignHTTP(ctx, c, req, hex.EncodeToString(sum[:]), "sts", region, now); err != nil {
+		return "", fmt.Errorf("sign GetCallerIdentity request: %w", err)
+	}
+
+	sts, err := json.Marshal(map[string]any{
+		"method":  http.MethodPost,
+		"url":     url,
+		"headers": req.Header,
+		"body":    body,
+	})
+	if err != nil {
+		return "", err
+	}
+	claims, err := json.Marshal(map[string]any{
+		"exp": now.Add(awsSTSTokenTTL).Unix(),
+		"aud": serverID,
+		"sts": json.RawMessage(sts),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// A JWT-shaped, unsigned envelope: header.claims with an empty signature
+	// segment. The header's alg=none + typ let the registry route this away from
+	// JWKS validation. cijwt ParseUnverified-reads only the exp; the registry
+	// decodes the "sts" claim and replays the signed request.
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"none","typ":"` + awsSTSTokenType + `"}`))
+	return header + "." + enc.EncodeToString(claims) + ".", nil
 }
 
 func resolveConfigPath(args []string) (string, error) {

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -68,8 +68,8 @@ func TestJWTTransportOptions(t *testing.T) {
 	t.Run("provider audience builds a transport with host as default aud", func(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
-			Host: "mint.example",
-			JWT:  &config.AuthJWT{Provider: config.JWTProviderForgejo},
+			Host:       "mint.example",
+			Credential: &config.AuthCredential{Provider: config.JWTProviderForgejo},
 		}}}
 		opts, err := jwtTransportOptions(http.DefaultTransport, auth)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -82,8 +82,8 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		t.Setenv("MY_CI_TOKEN", "env-token")
 		auth := &config.Auth{Hosts: []config.AuthHost{{
-			Host: "static.example",
-			JWT:  &config.AuthJWT{FromEnv: "MY_CI_TOKEN"},
+			Host:       "static.example",
+			Credential: &config.AuthCredential{FromEnv: "MY_CI_TOKEN"},
 		}}}
 		opts, err := jwtTransportOptions(http.DefaultTransport, auth)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -95,8 +95,8 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		t.Setenv("MY_CI_TOKEN", "")
 		auth := &config.Auth{Hosts: []config.AuthHost{{
-			Host: "static.example",
-			JWT:  &config.AuthJWT{FromEnv: "MY_CI_TOKEN"},
+			Host:       "static.example",
+			Credential: &config.AuthCredential{FromEnv: "MY_CI_TOKEN"},
 		}}}
 		_, err := jwtTransportOptions(http.DefaultTransport, auth)
 		g.Expect(err).To(MatchError(ContainSubstring("is not set or empty")))
@@ -105,8 +105,8 @@ func TestJWTTransportOptions(t *testing.T) {
 	t.Run("fromPath builds a token-file transport", func(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
-			Host: "static.example",
-			JWT:  &config.AuthJWT{FromPath: "/run/secrets/token"},
+			Host:       "static.example",
+			Credential: &config.AuthCredential{FromPath: "/run/secrets/token"},
 		}}}
 		opts, err := jwtTransportOptions(http.DefaultTransport, auth)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -118,7 +118,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: writeJWK(t),
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -135,7 +135,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: filepath.Join(t.TempDir(), "missing.json"),
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -149,7 +149,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: writeJWKS(t, 1),
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -165,7 +165,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: writeJWKS(t, 2),
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -180,7 +180,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		path := writeJWKFile(t, []byte(`{"keys":[]}`))
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: path,
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -195,7 +195,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		path := writeJWKFile(t, []byte("not json"))
 		auth := &config.Auth{Hosts: []config.AuthHost{{
 			Host: "registry.example",
-			JWT: &config.AuthJWT{
+			Credential: &config.AuthCredential{
 				JWKPath: path,
 				Iss:     "https://issuer.example",
 				Sub:     "client-id",
@@ -209,9 +209,9 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		t.Setenv("MY_CI_TOKEN", "env-token")
 		auth := &config.Auth{Hosts: []config.AuthHost{
-			{Host: "static.example", JWT: &config.AuthJWT{FromEnv: "MY_CI_TOKEN"}},
-			{Host: "mint.example", JWT: &config.AuthJWT{Provider: config.JWTProviderGitHub}},
-			{Host: "registry.example", JWT: &config.AuthJWT{
+			{Host: "static.example", Credential: &config.AuthCredential{FromEnv: "MY_CI_TOKEN"}},
+			{Host: "mint.example", Credential: &config.AuthCredential{Provider: config.JWTProviderGitHub}},
+			{Host: "registry.example", Credential: &config.AuthCredential{
 				JWKPath: writeJWK(t), Iss: "https://issuer.example", Sub: "client-id",
 			}},
 		}}

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,7 +36,7 @@ charts:
 |--------------|--------|---------|---------------------------------------------------------------------------------------------|
 | `apiVersion` | string |         | Must be `mirror.fluxcd.io/v1alpha1`.                                                        |
 | `kind`       | string |         | Must be `Config`.                                                                           |
-| `auth`       | object | `null`  | Per-host JWT authentication for outbound OCI registry requests. See [Auth](#auth).         |
+| `auth`       | object | `null`  | Per-host credential authentication for outbound OCI registry requests. See [Auth](#auth).  |
 | `artifacts`  | list   | `[]`    | OCI artifacts (images, OCI Helm charts, Flux artifacts, etc.). See [Artifacts](#artifacts). |
 | `charts`     | list   | `[]`    | Helm charts from HTTP/S or OCI Helm repositories. See [Charts](#charts).                    |
 
@@ -44,17 +44,17 @@ At least one of `artifacts` or `charts` must be set.
 
 ## Auth
 
-The optional `auth` section attaches a JWT credential to specific OCI registry
-hosts. On each request to a listed host, the JWT is sent as the
-`Authorization: Bearer <jwt>` credential. Requests to hosts that are **not**
+The optional `auth` section attaches a credential to specific OCI registry
+hosts. On each request to a listed host, the credential is sent as the
+`Authorization: Bearer <credential>` value. Requests to hosts that are **not**
 listed use the ambient keychain auth (Docker config `~/.docker/config.json` /
 `$DOCKER_CONFIG` and any configured credential helpers) instead.
 
 `auth` and the ambient credential files work together fine — **as long as each
 registry host is served by one or the other, not both.** Listing a host in
 `auth` *and* relying on ambient credentials for that same host is unsupported:
-the JWT and the keychain layer on top of each other in a registry-dependent way,
-and the result is undefined. Pick one mechanism per host.
+the credential and the keychain layer on top of each other in a registry-dependent
+way, and the result is undefined. Pick one mechanism per host.
 
 > This applies only to OCI registry requests — the `artifacts` section and
 > `oci://` Helm sources. HTTP/S Helm repositories are never affected by `auth`;
@@ -65,9 +65,9 @@ and the result is undefined. Pick one mechanism per host.
 auth:
   hosts:
     - host: registry.example.com
-      jwt:
-        # Exactly one of the following four selects how the token is obtained.
-        provider: github           # mint an OIDC ID token (github or forgejo)
+      credential:
+        # Exactly one of the following four selects how the credential is obtained.
+        provider: github           # mint a token (github, forgejo, gcp, azure, or aws)
         fromEnv: SOME_ENV_VAR      # send a static JWT read from this env var
         fromPath: /path/to/token   # send a static JWT read from this file
         jwkPath: /path/to/jwk.json # sign a fresh JWT per request with this key
@@ -84,7 +84,7 @@ auth:
 
 | Source     | Behavior                                                                                                                                                                                                  |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `provider` | Mints an OIDC ID token for `aud` from the GitHub/Forgejo Actions endpoint (`ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`). Cached for the first 50% of its lifetime, then reminted. One of: `github`, `forgejo`. |
+| `provider` | Mints a per-request credential for `aud`. `github`/`forgejo` use the Actions endpoint (`ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`); `gcp` uses Google Application Default Credentials (GKE/GCE metadata server, service account key, workload identity federation); `azure` uses the default Azure credential chain (AKS/managed identity, workload identity federation, environment credentials) and requests the `<aud>/.default` scope. `aws` is **not OIDC**: it signs an `sts:GetCallerIdentity` request with the ambient role credentials (IMDS, env, ...) and wraps it in a JWT-shaped envelope, with `aud` sent as a signed `X-Audience` header pinning the target registry. The registry verifies it by replaying the signed request to AWS STS and reading the caller's account/ARN — so the destination must understand this scheme (a generic OIDC registry will not). The envelope is tagged with the JOSE header `{"alg":"none","typ":"aws-sigv4-getcalleridentity"}` so the registry can route it away from JWKS validation; it must derive identity only from the STS response, never from the envelope's own claims. Cached and refreshed on demand. |
 | `fromEnv`  | Sends the JWT read from the named environment variable as-is (e.g. a GitLab CI `id_token`). Errors at runtime if the variable is unset or empty.                                                          |
 | `jwkPath`  | Signs a fresh, 60-second JWT on **every** request with the private Ed25519/ECDSA key in the JWK file at this path. The file may be a bare JWK or a JWK set (`{"keys":[...]}`) containing exactly one key. The key id is set in the `kid` header. Generate a key pair with [`flux-mirror keygen sig`](./keygen.md). |
 
@@ -93,7 +93,7 @@ auth:
 | Field      | Type   | Default | Description                                                                                  |
 |------------|--------|---------|---------------------------------------------------------------------------------------------|
 | `host`     | string |         | Registry host to authenticate. Required and unique across `hosts`.                           |
-| `provider` | string |         | OIDC provider, one of `github`, `forgejo`. Mutually exclusive with `fromEnv` and `jwkPath`.  |
+| `provider` | string |         | Token provider, one of `github`, `forgejo`, `gcp`, `azure`, `aws`. Mutually exclusive with `fromEnv`, `fromPath`, and `jwkPath`. |
 | `fromEnv`  | string |         | Environment variable holding a static JWT. Mutually exclusive with `provider` and `jwkPath`. |
 | `jwkPath`  | string |         | Path to a private JSON Web Key, as a bare JWK or a single-key JWK set. Mutually exclusive with `provider` and `fromEnv`. |
 | `iss`      | string |         | Token issuer. Required with `jwkPath`; not allowed otherwise.                                |

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,14 @@ module github.com/fluxcd/flux-mirror
 go 1.26.0
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Masterminds/semver/v3 v3.5.0
+	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/briandowns/spinner v1.23.2
 	github.com/distribution/distribution/v3 v3.1.1
-	github.com/fluxcd/pkg/auth v0.47.0
+	github.com/fluxcd/pkg/auth v0.51.0
 	github.com/fluxcd/pkg/helmtestserver v0.39.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -18,14 +22,20 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.278.0
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/apimachinery v0.36.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -33,6 +43,18 @@ require (
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -95,6 +117,9 @@ require (
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
@@ -109,6 +134,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
@@ -128,6 +154,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
@@ -217,5 +244,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-replace github.com/fluxcd/pkg/auth => github.com/fluxcd/pkg/auth v0.48.1-0.20260528153530-d116721aec83

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzU
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+8ez6T3HWXPmwOK7Yvq8QxDBD3SKY=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
@@ -33,6 +35,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
+github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
@@ -177,8 +181,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/cli-utils v1.2.0 h1:1o07pXTMxJ/XJ1GpAbLtjdXwfCUMq4Ku1OcnvJHLohI=
 github.com/fluxcd/cli-utils v1.2.0/go.mod h1:d5HdTDdR5sCbsIbgtOQ7x7srKYwYeZORU6CD2yn4j/M=
-github.com/fluxcd/pkg/auth v0.48.1-0.20260528153530-d116721aec83 h1:AyxW2wDCB2oLaZUtGM9Y1P3nK17lCYD7JKFU5IPPDhc=
-github.com/fluxcd/pkg/auth v0.48.1-0.20260528153530-d116721aec83/go.mod h1:fXzYmOvcWVzJwJ4iPFHYUJ1PvEqs221JIBcV2lhr/i4=
+github.com/fluxcd/pkg/auth v0.51.0 h1:yu5laG9dVyKGq2fDPem9gPTBfjdCEVPgKZ4M/oGAQWk=
+github.com/fluxcd/pkg/auth v0.51.0/go.mod h1:GWDfC5KhljE1ekKlfXVmod8H0uUm95ISlaAXULq2euk=
 github.com/fluxcd/pkg/helmtestserver v0.39.0 h1:ijmSe54BGWp6kRKt0WqtT8fBfTOYhV67hKaaHWg0kvs=
 github.com/fluxcd/pkg/helmtestserver v0.39.0/go.mod h1:z4beyhZLAMmGkk0vdY6VWX+C++Jp1gnGhVj2NcXOqN8=
 github.com/fluxcd/pkg/testserver v0.14.0 h1:wVv/JPY3i4OEJ8xakfriuN2oHiUyZZ+BfhC/6RCD2nI=
@@ -368,6 +372,8 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
@@ -584,8 +590,8 @@ go.opentelemetry.io/contrib/bridges/prometheus v0.67.0 h1:dkBzNEAIKADEaFnuESzcXv
 go.opentelemetry.io/contrib/bridges/prometheus v0.67.0/go.mod h1:Z5RIwRkZgauOIfnG5IpidvLpERjhTninpP1dTG2jTl4=
 go.opentelemetry.io/contrib/exporters/autoexport v0.67.0 h1:4fnRcNpc6YFtG3zsFw9achKn3XgmxPxuMuqIL5rE8e8=
 go.opentelemetry.io/contrib/exporters/autoexport v0.67.0/go.mod h1:qTvIHMFKoxW7HXg02gm6/Wofhq5p3Ib/A/NNt1EoBSQ=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 h1:XmiuHzgJt067+a6kwyAzkhXooYVv3/TOw9cM2VfJgUM=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0/go.mod h1:KDgtbWKTQs4bM+VPUr6WlL9m/WXcmkCcBlIzqxPGzmI=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:OyrsyzuttWTSur2qN/Lm0m2a8yqyIjUVBZcxFPuXq2o=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
@@ -666,6 +672,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
@@ -682,8 +689,8 @@ gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/api v0.278.0 h1:W7jiRvRi53VYFfZ/HoZjQBtJk7gOFbHD8ot1RzVZU6E=
 google.golang.org/api v0.278.0/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
-google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 h1:JNfk58HZ8lfmXbYK2vx/UvsqIL59TzByCxPIX4TDmsE=
-google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5/go.mod h1:x5julN69+ED4PcFk/XWayw35O0lf/nGa4aNgODCmNmw=
+google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgnawEVsOn6OFsnpyxNPRY9QV01dNB0=
+google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
 google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 h1:tEkOQcXgF6dH1G+MVKZrfpYvozGrzb91k6ha7jireSM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,21 @@ const (
 	// so the config can adapt to each platform's breaking changes.
 	JWTProviderGitHub  = "github"
 	JWTProviderForgejo = "forgejo"
+	// JWTProviderGCP mints a Google ID token for the audience via Application
+	// Default Credentials (GKE/GCE metadata server, service account key file,
+	// workload identity federation, ...).
+	JWTProviderGCP = "gcp"
+	// JWTProviderAzure mints a Microsoft Entra ID access token for the audience
+	// via the default Azure credential chain (AKS/managed identity, workload
+	// identity federation, environment credentials, ...).
+	JWTProviderAzure = "azure"
+	// JWTProviderAWS proves the caller's AWS identity to the registry. AWS mints
+	// no JWT, so instead of an OIDC token this signs an sts:GetCallerIdentity
+	// request with the ambient role credentials (IMDS, env, ...) and wraps it in
+	// a JWT-shaped envelope; the registry replays the signed request to STS to
+	// verify it and read the caller's account/ARN. aud pins the target registry
+	// via a signed header, not an OIDC audience claim.
+	JWTProviderAWS = "aws"
 
 	defaultChartVersion = "*"
 	defaultLimit        = 1
@@ -47,7 +62,7 @@ type Config struct {
 	Artifacts  []ArtifactEntry `json:"artifacts,omitempty"`
 }
 
-// Auth configures per-host JWT authentication for outbound OCI registry
+// Auth configures per-host credential authentication for outbound OCI registry
 // requests. Hosts that are not listed keep their ambient keychain
 // authentication; a given host should use either auth or ambient credentials,
 // not both. See docs/config.md#auth.
@@ -57,15 +72,17 @@ type Auth struct {
 
 // AuthHost binds an authentication method to a registry host.
 type AuthHost struct {
-	Host string   `json:"host"`
-	JWT  *AuthJWT `json:"jwt,omitempty"`
+	Host       string          `json:"host"`
+	Credential *AuthCredential `json:"credential,omitempty"`
 }
 
-// AuthJWT configures a per-host JWT credential. Exactly one of Provider,
-// FromEnv, FromPath, or JWKPath selects how the token is obtained:
+// AuthCredential configures a per-host credential. Exactly one of Provider,
+// FromEnv, FromPath, or JWKPath selects how the credential is obtained:
 //
-//   - Provider mints an OIDC ID token for Aud from a CI platform's Actions
-//     endpoint (see JWTProviderGitHub, JWTProviderForgejo).
+//   - Provider mints a per-request credential for Aud (an OIDC token for the
+//     OIDC providers, or a signed sts:GetCallerIdentity envelope for aws; see
+//     JWTProviderGitHub, JWTProviderForgejo, JWTProviderGCP, JWTProviderAzure,
+//     JWTProviderAWS).
 //   - FromEnv sends a static JWT read as-is from the named environment variable
 //     (e.g. a GitLab CI id_token).
 //   - FromPath sends a static JWT read from the file at the path, with leading
@@ -75,7 +92,7 @@ type AuthHost struct {
 //
 // Iss and Sub are required for, and may only be set with, JWKPath. Aud is
 // optional and may only be set with JWKPath or Provider; it defaults to Host.
-type AuthJWT struct {
+type AuthCredential struct {
 	Provider string `json:"provider,omitempty"`
 	FromEnv  string `json:"fromEnv,omitempty"`
 	FromPath string `json:"fromPath,omitempty"`
@@ -89,10 +106,10 @@ type AuthJWT struct {
 
 // EffectiveAud returns the audience with the documented default (the host) applied.
 func (h AuthHost) EffectiveAud() string {
-	if h.JWT == nil || strings.TrimSpace(h.JWT.Aud) == "" {
+	if h.Credential == nil || strings.TrimSpace(h.Credential.Aud) == "" {
 		return h.Host
 	}
-	return h.JWT.Aud
+	return h.Credential.Aud
 }
 
 // ChartEntry mirrors a Helm chart from an HTTP/S or OCI source to an OCI destination.
@@ -259,16 +276,16 @@ func (h AuthHost) validate() error {
 	if strings.TrimSpace(h.Host) == "" {
 		return fmt.Errorf("host is required")
 	}
-	if h.JWT == nil {
-		return fmt.Errorf("jwt is required")
+	if h.Credential == nil {
+		return fmt.Errorf("credential is required")
 	}
-	if err := h.JWT.validate(); err != nil {
-		return fmt.Errorf("jwt: %w", err)
+	if err := h.Credential.validate(); err != nil {
+		return fmt.Errorf("credential: %w", err)
 	}
 	return nil
 }
 
-func (j AuthJWT) validate() error {
+func (j AuthCredential) validate() error {
 	provider := strings.TrimSpace(j.Provider)
 	fromEnv := strings.TrimSpace(j.FromEnv)
 	fromPath := strings.TrimSpace(j.FromPath)
@@ -298,10 +315,10 @@ func (j AuthJWT) validate() error {
 		}
 	case provider != "":
 		switch provider {
-		case JWTProviderGitHub, JWTProviderForgejo:
+		case JWTProviderGitHub, JWTProviderForgejo, JWTProviderGCP, JWTProviderAzure, JWTProviderAWS:
 		default:
-			return fmt.Errorf("provider %q must be one of: %s, %s",
-				provider, JWTProviderGitHub, JWTProviderForgejo)
+			return fmt.Errorf("provider %q must be one of: %s, %s, %s, %s, %s",
+				provider, JWTProviderGitHub, JWTProviderForgejo, JWTProviderGCP, JWTProviderAzure, JWTProviderAWS)
 		}
 		if hasIss || hasSub {
 			return fmt.Errorf("iss and sub can only be set with jwkPath")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -242,28 +242,49 @@ func TestValidate_Table(t *testing.T) {
 			name: "auth valid provider",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{{
-					Host: "mint.example", JWT: &AuthJWT{Provider: JWTProviderGitHub, Aud: "custom"},
+					Host: "mint.example", Credential: &AuthCredential{Provider: JWTProviderGitHub, Aud: "custom"},
+				}}}},
+		},
+		{
+			name: "auth valid provider gcp",
+			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
+				Auth: &Auth{Hosts: []AuthHost{{
+					Host: "us-docker.pkg.dev", Credential: &AuthCredential{Provider: JWTProviderGCP, Aud: "custom"},
+				}}}},
+		},
+		{
+			name: "auth valid provider azure",
+			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
+				Auth: &Auth{Hosts: []AuthHost{{
+					Host: "myregistry.azurecr.io", Credential: &AuthCredential{Provider: JWTProviderAzure, Aud: "custom"},
+				}}}},
+		},
+		{
+			name: "auth valid provider aws",
+			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
+				Auth: &Auth{Hosts: []AuthHost{{
+					Host: "registry.example.com", Credential: &AuthCredential{Provider: JWTProviderAWS, Aud: "custom"},
 				}}}},
 		},
 		{
 			name: "auth valid fromEnv",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{{
-					Host: "static.example", JWT: &AuthJWT{FromEnv: "TOKEN"},
+					Host: "static.example", Credential: &AuthCredential{FromEnv: "TOKEN"},
 				}}}},
 		},
 		{
 			name: "auth valid fromPath",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{{
-					Host: "static.example", JWT: &AuthJWT{FromPath: "/run/secrets/token"},
+					Host: "static.example", Credential: &AuthCredential{FromPath: "/run/secrets/token"},
 				}}}},
 		},
 		{
 			name: "auth valid jwkPath",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{{
-					Host: "registry.example", JWT: &AuthJWT{
+					Host: "registry.example", Credential: &AuthCredential{
 						JWKPath: "/path/jwk.json", Iss: "https://issuer", Sub: "client", Aud: "registry.example",
 					},
 				}}}},
@@ -277,34 +298,34 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth missing host",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{JWT: &AuthJWT{FromEnv: "TOKEN"}}}}},
+				Auth: &Auth{Hosts: []AuthHost{{Credential: &AuthCredential{FromEnv: "TOKEN"}}}}},
 			errMsg: "host is required",
 		},
 		{
-			name: "auth missing jwt",
+			name: "auth missing credential",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example"}}}},
-			errMsg: "jwt is required",
+			errMsg: "credential is required",
 		},
 		{
 			name: "auth duplicate host",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
 				Auth: &Auth{Hosts: []AuthHost{
-					{Host: "dup.example", JWT: &AuthJWT{FromEnv: "A"}},
-					{Host: "dup.example", JWT: &AuthJWT{FromEnv: "B"}},
+					{Host: "dup.example", Credential: &AuthCredential{FromEnv: "A"}},
+					{Host: "dup.example", Credential: &AuthCredential{FromEnv: "B"}},
 				}}},
 			errMsg: "configured more than once",
 		},
 		{
 			name: "auth no source set",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{}}}}},
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{}}}}},
 			errMsg: "exactly one of provider, fromEnv, fromPath, or jwkPath",
 		},
 		{
 			name: "auth two sources set",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					Provider: JWTProviderGitHub, FromEnv: "TOKEN",
 				}}}}},
 			errMsg: "exactly one of provider, fromEnv, fromPath, or jwkPath",
@@ -312,15 +333,15 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth invalid provider",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					Provider: "gitlab",
 				}}}}},
-			errMsg: "must be one of: github, forgejo",
+			errMsg: "must be one of: github, forgejo, gcp, azure, aws",
 		},
 		{
 			name: "auth jwkPath missing iss",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					JWKPath: "/k.json", Sub: "client",
 				}}}}},
 			errMsg: "iss is required with jwkPath",
@@ -328,7 +349,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth jwkPath missing sub",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					JWKPath: "/k.json", Iss: "https://issuer",
 				}}}}},
 			errMsg: "sub is required with jwkPath",
@@ -336,7 +357,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth iss set without jwkPath",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					Provider: JWTProviderGitHub, Iss: "https://issuer",
 				}}}}},
 			errMsg: "iss and sub can only be set with jwkPath",
@@ -344,7 +365,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth aud set with fromEnv",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					FromEnv: "TOKEN", Aud: "nope",
 				}}}}},
 			errMsg: "aud can only be set with jwkPath or provider",
@@ -352,7 +373,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth aud set with fromPath",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					FromPath: "/path/token", Aud: "nope",
 				}}}}},
 			errMsg: "aud can only be set with jwkPath or provider",
@@ -360,7 +381,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth iss set with fromPath",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					FromPath: "/path/token", Iss: "https://issuer",
 				}}}}},
 			errMsg: "iss and sub can only be set with jwkPath",
@@ -368,7 +389,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth fromPath and fromEnv set",
 			cfg: Config{APIVersion: APIVersion, Kind: Kind, Artifacts: validArtifact(),
-				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", JWT: &AuthJWT{
+				Auth: &Auth{Hosts: []AuthHost{{Host: "h.example", Credential: &AuthCredential{
 					FromEnv: "TOKEN", FromPath: "/path/token",
 				}}}}},
 			errMsg: "exactly one of provider, fromEnv, fromPath, or jwkPath",

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -71,7 +71,26 @@ func Start(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("new registry: %w", err)
 	}
 	go func() { _ = reg.ListenAndServe() }()
-	return host, nil
+
+	// ListenAndServe binds the socket asynchronously, so block until the
+	// registry actually accepts a connection. Without this, callers race the
+	// goroutine and hit connection-refused on a loaded runner.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		conn, derr := net.DialTimeout("tcp", host, 200*time.Millisecond)
+		if derr == nil {
+			_ = conn.Close()
+			return host, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("registry not ready at %s: %w", host, derr)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
 // UseEmptyDockerConfig points Docker-aware clients at an empty config for the


### PR DESCRIPTION
⚠️ **Breaking change**: Moving `Config.auth.hosts[].jwt` to `Config.auth.hosts[].credential`. This is because all providers issue JWTs except `aws`,  which issues a pseudo JWT instead just to make it easier for parsers, but whose cryptographic material is validated in an entirely different way due to how AWS works.

This PR introduces a way for users to implement workload identity through cloud provider environments that are not necessarily Kubernetes clusters (in which case `.credential.fromPath` could be used along the cluster's OIDC issuer URL instead of `.credential.provider`). This could still be a Kubernetes cluster from a cloud provider configured with an IAM identity via workload identity (e.g. EKS Pod Identity) with the difference that an IAM identity credential is issued instead of a Kubernetes ServiceAccount token. This could also be a VM from the cloud provider, a GitHub Actions workflow job that used those cloud provider login actions, or even a local dev machine where IAM credentials are configured e.g. via SSO or static credentials.

**Note**: This feature *is not* for authenticating against ECR, ACR and GAR. This feature is for authenticating against a container registry that understands identity credentials from cloud providers. This is useful because it may be much easier to create a single (or a few) IAM identity and reuse it for hundreds of clusters rather than configuring one OIDC issuer URL per cluster for hundreds of clusters. Support for ECR, ACR and GAR will be introduced in a subsequent PR.