### PR TITLE
Introduce `auth.hosts[].credential.username`

### DIFF
--- a/cmd/flux-mirror/create_secret.go
+++ b/cmd/flux-mirror/create_secret.go
@@ -118,12 +118,15 @@ func createSecretCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// dockerConfigEntry is one registry's credentials in a dockerconfigjson, base64
-// auth and all, matching what 'kubectl create secret docker-registry' writes.
+// dockerConfigEntry is one registry's credentials in a dockerconfigjson. A
+// username/password pair (with the base64 auth) matches what 'kubectl create
+// secret docker-registry' writes; registrytoken is the non-standard bearer-token
+// field understood by go-containerregistry (crane, Flux).
 type dockerConfigEntry struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
 // buildDockerConfigSecret assembles a kubernetes.io/dockerconfigjson Secret from
@@ -131,6 +134,10 @@ type dockerConfigEntry struct {
 func buildDockerConfigSecret(name, namespace string, creds map[string]registryauth.HostAuth) (*corev1.Secret, error) {
 	auths := make(map[string]dockerConfigEntry, len(creds))
 	for host, ha := range creds {
+		if ha.RegistryToken != "" {
+			auths[host] = dockerConfigEntry{RegistryToken: ha.RegistryToken}
+			continue
+		}
 		auths[host] = dockerConfigEntry{
 			Username: ha.Username,
 			Password: ha.Password,

--- a/cmd/flux-mirror/create_secret_test.go
+++ b/cmd/flux-mirror/create_secret_test.go
@@ -20,7 +20,8 @@ import (
 func TestBuildDockerConfigSecret(t *testing.T) {
 	g := NewWithT(t)
 	secret, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{
-		"registry.example.com": {Username: registryauth.Username, Password: "token-value"},
+		"user.example.com":  {Username: "robot", Password: "token-value"},
+		"token.example.com": {RegistryToken: "bearer-token"},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(secret.Name).To(Equal("regcreds"))
@@ -33,13 +34,22 @@ func TestBuildDockerConfigSecret(t *testing.T) {
 		Auths map[string]dockerConfigEntry `json:"auths"`
 	}
 	g.Expect(json.Unmarshal(raw, &parsed)).To(Succeed())
-	entry, ok := parsed.Auths["registry.example.com"]
-	g.Expect(ok).To(BeTrue())
-	g.Expect(entry.Username).To(Equal(registryauth.Username))
-	g.Expect(entry.Password).To(Equal("token-value"))
-	dec, err := base64.StdEncoding.DecodeString(entry.Auth)
+
+	// Username host => username/password/auth, no registrytoken.
+	up := parsed.Auths["user.example.com"]
+	g.Expect(up.Username).To(Equal("robot"))
+	g.Expect(up.Password).To(Equal("token-value"))
+	g.Expect(up.RegistryToken).To(BeEmpty())
+	dec, err := base64.StdEncoding.DecodeString(up.Auth)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(string(dec)).To(Equal(registryauth.Username + ":token-value"))
+	g.Expect(string(dec)).To(Equal("robot:token-value"))
+
+	// Token host => registrytoken only, no username/password/auth.
+	tok := parsed.Auths["token.example.com"]
+	g.Expect(tok.RegistryToken).To(Equal("bearer-token"))
+	g.Expect(tok.Auth).To(BeEmpty())
+	g.Expect(tok.Username).To(BeEmpty())
+	g.Expect(tok.Password).To(BeEmpty())
 }
 
 func TestApplySecret_CreateThenReplace(t *testing.T) {
@@ -47,14 +57,14 @@ func TestApplySecret_CreateThenReplace(t *testing.T) {
 	ctx := context.Background()
 	client := fake.NewClientset()
 
-	s1, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{"a.example": {Username: registryauth.Username, Password: "v1"}})
+	s1, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{"a.example": {Username: "robot", Password: "v1"}})
 	g.Expect(err).ToNot(HaveOccurred())
 	created, err := applySecret(ctx, client, s1)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(created).To(BeTrue())
 
 	// Second apply with new data replaces the existing secret.
-	s2, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{"a.example": {Username: registryauth.Username, Password: "v2"}})
+	s2, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{"a.example": {Username: "robot", Password: "v2"}})
 	g.Expect(err).ToNot(HaveOccurred())
 	created, err = applySecret(ctx, client, s2)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/cmd/flux-mirror/login.go
+++ b/cmd/flux-mirror/login.go
@@ -95,6 +95,20 @@ func loginCmdRun(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("host %q: %w", h.Host, err)
 		}
 
+		// A bearer RegistryToken can't live in a credential helper (those store
+		// username/secret pairs), so it always goes to the config file. A
+		// username/password pair respects --plaintext and any configured helper.
+		if ha.RegistryToken != "" {
+			if err := credentials.NewFileStore(dcf).Store(types.AuthConfig{
+				ServerAddress: h.Host,
+				RegistryToken: ha.RegistryToken,
+			}); err != nil {
+				return fmt.Errorf("store docker credential for %q: %w", h.Host, err)
+			}
+			cmd.Printf("✔ stored registry token for %s in %s\n", h.Host, dcf.Filename)
+			continue
+		}
+
 		var store credentials.Store
 		if loginArgs.plaintext {
 			// Force a base64 config.json entry, bypassing any helper.

--- a/cmd/flux-mirror/login_test.go
+++ b/cmd/flux-mirror/login_test.go
@@ -15,8 +15,6 @@ import (
 
 	gojwt "github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/gomega"
-
-	"github.com/fluxcd/flux-mirror/internal/registryauth"
 )
 
 // writeLoginConfig writes a valid config whose single auth host carries the
@@ -55,9 +53,10 @@ func parseUnverified(t *testing.T, token string) gojwt.MapClaims {
 }
 
 // loginStore runs `login` for the standard test host storing into a fresh,
-// plaintext Docker config dir, and returns the password stored for it (the part
-// after the first colon of the decoded auth entry). --plaintext keeps the test
-// off any OS keychain helper.
+// plaintext Docker config dir, and returns the credential stored for it: the
+// registrytoken when present (credential hosts without a username), otherwise
+// the password from the decoded auth entry. --plaintext keeps the test off any
+// OS keychain helper.
 func loginStore(t *testing.T, configRef, input string) (string, error) {
 	t.Helper()
 	const host = "registry.example.com"
@@ -72,7 +71,8 @@ func loginStore(t *testing.T, configRef, input string) (string, error) {
 	}
 	var parsed struct {
 		Auths map[string]struct {
-			Auth string `json:"auth"`
+			Auth          string `json:"auth"`
+			RegistryToken string `json:"registrytoken"`
 		} `json:"auths"`
 	}
 	if err := json.Unmarshal(data, &parsed); err != nil {
@@ -81,6 +81,9 @@ func loginStore(t *testing.T, configRef, input string) (string, error) {
 	entry, ok := parsed.Auths[host]
 	if !ok {
 		return "", fmt.Errorf("no auth entry for %q", host)
+	}
+	if entry.RegistryToken != "" {
+		return entry.RegistryToken, nil
 	}
 	dec, err := base64.StdEncoding.DecodeString(entry.Auth)
 	if err != nil {
@@ -213,7 +216,7 @@ auth:
 	g.Expect(err).To(MatchError(ContainSubstring("config has no entries")))
 }
 
-func TestLogin_PlaintextStoresUserAndPassword(t *testing.T) {
+func TestLogin_StoresRegistryToken(t *testing.T) {
 	g := NewWithT(t)
 	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
 	cfg := writeLoginConfig(t, "        fromEnv: MY_LOGIN_TOKEN\n")
@@ -229,15 +232,48 @@ func TestLogin_PlaintextStoresUserAndPassword(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	var parsed struct {
 		Auths map[string]struct {
-			Auth string `json:"auth"`
+			Auth          string `json:"auth"`
+			Username      string `json:"username"`
+			Password      string `json:"password"`
+			RegistryToken string `json:"registrytoken"`
 		} `json:"auths"`
 	}
 	g.Expect(json.Unmarshal(data, &parsed)).To(Succeed())
 	entry, ok := parsed.Auths["registry.example.com"]
 	g.Expect(ok).To(BeTrue())
+	// No username => bearer registrytoken, no username/password/auth.
+	g.Expect(entry.RegistryToken).To(Equal("static-token-value"))
+	g.Expect(entry.Auth).To(BeEmpty())
+	g.Expect(entry.Username).To(BeEmpty())
+	g.Expect(entry.Password).To(BeEmpty())
+}
+
+func TestLogin_UsernameStoresUserPassword(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
+	cfg := writeLoginConfig(t, "        fromEnv: MY_LOGIN_TOKEN\n        username: robot\n")
+	dockerDir := t.TempDir()
+
+	_, err := executeCommand([]string{
+		"login", "--host", "registry.example.com", "--config", cfg, "--docker-config", dockerDir, "--plaintext",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	data, err := os.ReadFile(filepath.Join(dockerDir, "config.json"))
+	g.Expect(err).ToNot(HaveOccurred())
+	var parsed struct {
+		Auths map[string]struct {
+			Auth          string `json:"auth"`
+			RegistryToken string `json:"registrytoken"`
+		} `json:"auths"`
+	}
+	g.Expect(json.Unmarshal(data, &parsed)).To(Succeed())
+	entry := parsed.Auths["registry.example.com"]
+	// Username set => standard username/password/auth, no registrytoken.
+	g.Expect(entry.RegistryToken).To(BeEmpty())
 	dec, err := base64.StdEncoding.DecodeString(entry.Auth)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(string(dec)).To(Equal(registryauth.Username + ":static-token-value"))
+	g.Expect(string(dec)).To(Equal("robot:static-token-value"))
 }
 
 func TestLogin_AllHostsByDefault(t *testing.T) {
@@ -266,19 +302,13 @@ auth:
 	g.Expect(err).ToNot(HaveOccurred())
 	var parsed struct {
 		Auths map[string]struct {
-			Auth string `json:"auth"`
+			RegistryToken string `json:"registrytoken"`
 		} `json:"auths"`
 	}
 	g.Expect(json.Unmarshal(data, &parsed)).To(Succeed())
 	g.Expect(parsed.Auths).To(HaveLen(2))
-	password := func(host string) string {
-		dec, derr := base64.StdEncoding.DecodeString(parsed.Auths[host].Auth)
-		g.Expect(derr).ToNot(HaveOccurred())
-		_, pass, _ := strings.Cut(string(dec), ":")
-		return pass
-	}
-	g.Expect(password("a.example.com")).To(Equal("cred-a"))
-	g.Expect(password("b.example.com")).To(Equal("cred-b"))
+	g.Expect(parsed.Auths["a.example.com"].RegistryToken).To(Equal("cred-a"))
+	g.Expect(parsed.Auths["b.example.com"].RegistryToken).To(Equal("cred-b"))
 }
 
 func TestLogin_HostNotFound(t *testing.T) {

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -157,7 +157,7 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 	} else if t != nil {
 		clientOpts = append(clientOpts, oci.WithTransport(t))
 	}
-	if kc, err := registryauth.BuildProviderKeychain(cmd.Context(), cfg.Auth); err != nil {
+	if kc, err := registryauth.BuildKeychain(cmd.Context(), cfg.Auth); err != nil {
 		return err
 	} else if kc != nil {
 		clientOpts = append(clientOpts, oci.WithKeychain(kc))
@@ -278,7 +278,7 @@ func classifyExit(r sync.Result, driftExitCode int) error {
 func buildClientTransport(auth *config.Auth) (http.RoundTripper, error) {
 	// Only credential hosts use the cijwt transport; provider hosts authenticate
 	// through the keychain instead.
-	credSet := registryauth.HasCredentialHosts(auth)
+	credSet := registryauth.NeedsCredentialTransport(auth)
 	chunkSet := syncArgs.maxChunkSize > 0
 	if !credSet && !chunkSet {
 		return nil, nil

--- a/docs/config.md
+++ b/docs/config.md
@@ -88,10 +88,32 @@ auth:
         # Optional; allowed only with jwkPath. JWT lifetime; defaults to 60s.
         exp: 1h
 
+        # Optional. Changes how the credential is presented (see below).
+        username: robot
+
     # Form 2: a cloud registry provider (ECR/ACR/GAR), via ambient workload identity.
     - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
       provider: ecr               # one of ecr, acr, gar
 ```
+
+### Bearer token vs. username/password (`credential.username`)
+
+`username` controls how the resolved credential is presented to the registry:
+
+- **Unset (default)** — the credential is a **bearer token**. `sync` sends it as
+  `Authorization: Bearer` on every request (no auth challenge), and
+  `login`/`create secret` write it to the Docker config's `registrytoken` field.
+  This suits registries that validate an OIDC token natively. `registrytoken` is
+  non-standard but understood by go-containerregistry (crane, Flux); it is **not**
+  understood by `kubelet` image pulls.
+- **Set** — the credential becomes the **password** of a `username`/`password`
+  pair. `sync` goes through the **standard registry auth challenge** (like the
+  cloud providers — credentials are exchanged at the token endpoint), and
+  `login`/`create secret` write `username`/`password`/`auth`.
+
+> ⚠️ Breaking change: credentials without `username` now default to
+> `registrytoken` in `login`/`create secret` output (previously a placeholder
+> `username`/`password`). Set `username` to restore `username`/`password`/`auth`.
 
 ### Registry providers
 
@@ -131,6 +153,7 @@ which are on the host itself. Each host sets exactly one of `credential` or
 | `sub`      | string |         | Token subject. Required with `jwkPath`; not allowed otherwise.                               |
 | `aud`      | string | `host`  | Token audience. Allowed only with `jwkPath` or `provider`; defaults to `host`.               |
 | `exp`      | duration | `60s` | JWT lifetime (e.g. `1h`). Allowed only with `jwkPath` — the one source whose lifetime flux-mirror controls. Must be positive. Other sources' lifetimes are fixed by their issuer. |
+| `username` | string |   | When unset, the credential is a bearer token (`registrytoken` / `Authorization: Bearer`). When set, the credential is the password of a `username`/`password` pair, using the standard registry auth challenge. See [Bearer token vs. username/password](#bearer-token-vs-usernamepassword-credentialusername). |
 
 ## Artifacts
 

--- a/docs/create.md
+++ b/docs/create.md
@@ -49,9 +49,11 @@ in-cluster service-account namespace).
   in-cluster config and service-account namespace).
 - With no `--host`, every host in `auth.hosts` is included. A `--host` that is
   not present in the config is an error.
-- The Secret's `.dockerconfigjson` holds one `auths` entry per host, each with a
-  placeholder username (`flux-mirror`) and the resolved credential as the
-  password — the identity is carried entirely by the credential.
+- The Secret's `.dockerconfigjson` holds one `auths` entry per host. A cloud
+  `provider` host, and a `credential` host with `username` set, write
+  `username`/`password`/`auth`. A `credential` host **without** `username` writes
+  the bearer `registrytoken` field (understood by go-containerregistry/Flux, not
+  by `kubelet`). See [`credential.username`](./config.md#bearer-token-vs-usernamepassword-credentialusername).
 - Credentials are short-lived (provider tokens, freshly signed JWTs). Re-run the
   command to refresh the Secret before they expire; it replaces the existing one
   in place.

--- a/docs/login.md
+++ b/docs/login.md
@@ -29,11 +29,19 @@ exactly like `docker login`:
   plaintext fallback `docker login` uses when no helper is available).
 
 The config location follows Docker's own discovery (`--docker-config`, else
-`$DOCKER_CONFIG`, else `~/.docker`). The stored username is a placeholder
-(`flux-mirror`) — the identity is carried entirely by the credential.
+`$DOCKER_CONFIG`, else `~/.docker`).
+
+What gets written depends on the host:
+- A cloud `provider` host, or a `credential` host with `username` set, writes
+  `username`/`password`/`auth`.
+- A `credential` host **without** `username` writes the bearer `registrytoken`
+  field instead. Because credential helpers only store username/secret pairs, a
+  `registrytoken` always goes to the config **file** (never a keychain helper).
+  See [`credential.username`](./config.md#bearer-token-vs-usernamepassword-credentialusername).
 
 Pass `--plaintext` to force the base64 `config.json` entry and bypass any
-configured or auto-detected credential helper.
+configured or auto-detected credential helper (applies to the username/password
+case; registrytoken is always file-based).
 
 ## What the credential is
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,13 @@ type AuthHost struct {
 // whose lifetime flux-mirror controls; it defaults to a short 60s. Every other
 // source's lifetime is fixed by an external issuer or is an opaque static
 // token, so Exp is rejected for them.
+//
+// Username changes how the credential is presented. When unset, the credential
+// is a bearer token: sync stamps it as Authorization: Bearer (no auth
+// challenge), and login/create write it to the Docker config's registrytoken
+// field. When set, the credential becomes the password of a username/password
+// pair: sync goes through the standard registry auth challenge (like the cloud
+// providers), and login/create write username/password/auth.
 type AuthCredential struct {
 	Provider string `json:"provider,omitempty"`
 	FromEnv  string `json:"fromEnv,omitempty"`
@@ -122,8 +129,9 @@ type AuthCredential struct {
 	Iss string `json:"iss,omitempty"`
 	Sub string `json:"sub,omitempty"`
 
-	Aud string           `json:"aud,omitempty"`
-	Exp *metav1.Duration `json:"exp,omitempty"`
+	Aud      string           `json:"aud,omitempty"`
+	Exp      *metav1.Duration `json:"exp,omitempty"`
+	Username string           `json:"username,omitempty"`
 }
 
 // EffectiveExp returns the jwkPath JWT lifetime with the documented default

--- a/internal/registryauth/credential.go
+++ b/internal/registryauth/credential.go
@@ -35,11 +35,6 @@ import (
 	"github.com/fluxcd/flux-mirror/internal/jwkio"
 )
 
-// Username is the placeholder username stored alongside a credential-host token.
-// The identity is carried entirely by the token (the password), so the username
-// is just a non-empty placeholder; token-auth registries ignore it.
-const Username = "flux-mirror"
-
 // resolveCredential mints or reads the credential for a single credential host,
 // mirroring what jwtTransportOptions wires into the sync transport but returning
 // the value directly. It assumes the config has passed validation (exactly one

--- a/internal/registryauth/registryauth.go
+++ b/internal/registryauth/registryauth.go
@@ -18,10 +18,13 @@ import (
 	"github.com/fluxcd/flux-mirror/internal/jwkio"
 )
 
-// HostAuth is a resolved username/password pair for a registry host.
+// HostAuth is a resolved credential for a registry host. Either RegistryToken is
+// set (a bearer token, for credential hosts without a username), or Username and
+// Password are set (provider hosts, and credential hosts with a username).
 type HostAuth struct {
-	Username string
-	Password string
+	Username      string
+	Password      string
+	RegistryToken string
 }
 
 // SelectAuthHosts returns the auth hosts to act on: the ones named in filter
@@ -48,9 +51,12 @@ func SelectAuthHosts(cfg *config.Config, filter []string) ([]config.AuthHost, er
 	return out, nil
 }
 
-// ResolveHostAuth resolves the username and password for any auth host: a
-// provider host yields the cloud registry credentials; a credential host yields
-// the placeholder username and the minted/static credential as the password.
+// ResolveHostAuth resolves the credential for any auth host:
+//   - a provider host yields the cloud registry username/password;
+//   - a credential host with a username yields that username and the
+//     minted/static credential as the password;
+//   - a credential host without a username yields the credential as a bearer
+//     RegistryToken.
 func ResolveHostAuth(ctx context.Context, h config.AuthHost) (HostAuth, error) {
 	if h.Provider != "" {
 		a, err := providerAuthenticator(ctx, h)
@@ -67,7 +73,10 @@ func ResolveHostAuth(ctx context.Context, h config.AuthHost) (HostAuth, error) {
 	if err != nil {
 		return HostAuth{}, err
 	}
-	return HostAuth{Username: Username, Password: cred}, nil
+	if h.Credential.Username != "" {
+		return HostAuth{Username: h.Credential.Username, Password: cred}, nil
+	}
+	return HostAuth{RegistryToken: cred}, nil
 }
 
 // pkgAuthProviderName maps a flux-mirror registry provider (ecr/acr/gar) to the
@@ -115,23 +124,48 @@ func (k providerKeychain) Resolve(res authn.Resource) (authn.Authenticator, erro
 	return k.inner.Resolve(res)
 }
 
-// BuildProviderKeychain pre-fetches credentials for every provider host and
-// returns a keychain serving them over the ambient Docker config. It returns
-// nil when no host uses a provider, so callers keep the default keychain.
-func BuildProviderKeychain(ctx context.Context, auth *config.Auth) (authn.Keychain, error) {
+// mintingAuthenticator resolves a credential host's username/password on each
+// call, so go-containerregistry re-mints (e.g. a fresh jwkPath JWT) whenever it
+// refreshes the registry token. Used for credential hosts that set a username.
+type mintingAuthenticator struct {
+	host config.AuthHost
+}
+
+// Authorization implements authn.Authenticator.
+func (m mintingAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	return m.AuthorizationContext(context.Background())
+}
+
+// AuthorizationContext implements authn.ContextAuthenticator.
+func (m mintingAuthenticator) AuthorizationContext(ctx context.Context) (*authn.AuthConfig, error) {
+	cred, err := resolveCredential(ctx, m.host)
+	if err != nil {
+		return nil, err
+	}
+	return &authn.AuthConfig{Username: m.host.Credential.Username, Password: cred}, nil
+}
+
+// BuildKeychain returns a keychain that serves the hosts which authenticate
+// through the standard registry auth challenge — cloud provider hosts and
+// credential hosts with a username — over the ambient Docker config. Provider
+// credentials are pre-fetched; username credentials are minted on demand.
+// Returns nil when no such host exists, so callers keep the default keychain.
+func BuildKeychain(ctx context.Context, auth *config.Auth) (authn.Keychain, error) {
 	if auth == nil {
 		return nil, nil
 	}
 	auths := make(map[string]authn.Authenticator)
 	for _, h := range auth.Hosts {
-		if h.Provider == "" {
-			continue
+		switch {
+		case h.Provider != "":
+			a, err := providerAuthenticator(ctx, h)
+			if err != nil {
+				return nil, err
+			}
+			auths[h.Host] = a
+		case h.Credential != nil && h.Credential.Username != "":
+			auths[h.Host] = mintingAuthenticator{host: h}
 		}
-		a, err := providerAuthenticator(ctx, h)
-		if err != nil {
-			return nil, err
-		}
-		auths[h.Host] = a
 	}
 	if len(auths) == 0 {
 		return nil, nil
@@ -139,14 +173,16 @@ func BuildProviderKeychain(ctx context.Context, auth *config.Auth) (authn.Keycha
 	return providerKeychain{auths: auths, inner: authn.DefaultKeychain}, nil
 }
 
-// HasCredentialHosts reports whether any host uses a JWT credential (as opposed
-// to a cloud provider), i.e. whether the cijwt transport is needed.
-func HasCredentialHosts(auth *config.Auth) bool {
+// NeedsCredentialTransport reports whether the cijwt bearer-stamp transport is
+// needed: true when any credential host has no username (a bearer token stamped
+// directly). Credential hosts with a username and provider hosts go through the
+// keychain instead.
+func NeedsCredentialTransport(auth *config.Auth) bool {
 	if auth == nil {
 		return false
 	}
 	for _, h := range auth.Hosts {
-		if h.Credential != nil {
+		if h.Credential != nil && h.Credential.Username == "" {
 			return true
 		}
 	}
@@ -174,8 +210,9 @@ func JWTTransportOptions(inner http.RoundTripper, auth *config.Auth) ([]cijwt.Op
 	opts := []cijwt.Option{cijwt.WithInner(inner)}
 
 	for _, h := range auth.Hosts {
-		if h.Credential == nil {
-			// Provider host: authenticated via the keychain, not cijwt.
+		if h.Credential == nil || h.Credential.Username != "" {
+			// Provider hosts and username credentials authenticate via the
+			// keychain (standard challenge), not the cijwt bearer-stamp.
 			continue
 		}
 		j := h.Credential

--- a/internal/registryauth/registryauth_test.go
+++ b/internal/registryauth/registryauth_test.go
@@ -4,6 +4,7 @@
 package registryauth
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -49,6 +50,33 @@ func TestSelectAuthHosts_NoAuth(t *testing.T) {
 	g := NewWithT(t)
 	_, err := SelectAuthHosts(&config.Config{}, nil)
 	g.Expect(err).To(MatchError(ContainSubstring("no auth.hosts")))
+}
+
+func TestUsernameSwitch(t *testing.T) {
+	g := NewWithT(t)
+
+	bearer := &config.Auth{Hosts: []config.AuthHost{{
+		Host: "bearer.example", Credential: &config.AuthCredential{FromEnv: "X"},
+	}}}
+	userpass := &config.Auth{Hosts: []config.AuthHost{{
+		Host: "userpass.example", Credential: &config.AuthCredential{FromEnv: "X", Username: "robot"},
+	}}}
+
+	// cijwt (bearer-stamp) transport is needed only when a credential host has
+	// no username.
+	g.Expect(NeedsCredentialTransport(bearer)).To(BeTrue())
+	g.Expect(NeedsCredentialTransport(userpass)).To(BeFalse())
+
+	// A username credential is skipped by the cijwt options (goes via keychain).
+	t.Setenv("X", "tok")
+	opts, err := JWTTransportOptions(nil, userpass)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(opts).To(HaveLen(1)) // only WithInner; the host is skipped
+
+	// ...and is served by the keychain instead.
+	kc, err := BuildKeychain(context.Background(), userpass)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(kc).ToNot(BeNil())
 }
 
 func TestPkgAuthProviderName(t *testing.T) {


### PR DESCRIPTION
Closes: #34

@stefanprodan Thanks very much for noticing the limitation, it prompted me to solve a problem that was on the back of my mind for days.

⚠️ **Breaking change**: The `login` and `create secret` commands now stamp a `registrytoken` field in the exported Docker config instead of `username`/`password`/`auth` for credentials obtained via `auth.hosts[].credential`. To opt back into the previous behavior (`username`/`password`/`auth`), users must specify `auth.hosts[].credential.username`. The `sync` command is consistent with this split: no `username`, it stamps a Bearer token in the HTTP requests. With `username` set, it initiates the standard auth challenge:

https://distribution.github.io/distribution/spec/auth/token/

`registrytoken` is the Docker config field for Bearer tokens, i.e. it's a supported way to bypass the standard auth challenge. Both `crane` (i.e. `go-containerregistry`) and `docker` honor this field.