### PR TITLE
Introduce sync structured report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ These rules come from [`fluxcd/flux2/CONTRIBUTING.md`](https://github.com/fluxcd
   ```sh
   git commit -s -m "Add feature X" --trailer "Assisted-by: <agent-name>/<model-id>"
   ```
-  The `-s` flag adds the human's `Signed-off-by` from their git config - do not remove it.
+  Use this only when explicitly asked to commit. The `-s` flag adds the human's `Signed-off-by` from their git config - do not remove it.
 - **Commit message format:** Subject in imperative mood ("Add feature X" instead of "Adding feature X"), capitalized, no trailing period, <=50 characters.
-- **Commit body:** Add a succinct explanation explaining what and why, wrap at 72 characters.
+- **Commit body:** Add a succinct explanation of what changed and why, wrap at 72 characters.
 - **Trim verbiage:** in PR descriptions, commit messages, and code comments. No marketing prose, no restating the diff, no emojis.
 - **Rebase, don't merge:** Never merge `main` into the feature branch; rebase onto the latest `main` and push with `--force-with-lease`. Squash before merge when asked.
 - **Tests:** New features, improvements and fixes must have test coverage.
@@ -26,7 +26,7 @@ Read the [README](README.md) for an overview of the project and its features.
 
 ### Code Structure
 
-- `cmd/flux-mirror/` - the `main` package. One file per cobra command or command concern (`sync.go`, `version.go`, `completion.go`, `progress.go`, `logging.go`). `main.VERSION` is overridden at build time by the Makefile.
+- `cmd/flux-mirror/` - the `main` package. One file per cobra command or command concern (`sync.go`, `login.go`, `create_secret.go`, `keygen.go`, `version.go`, `completion.go`, `progress.go`, `logging.go`). `main.VERSION` is overridden at build time by the Makefile.
 - `cmd/flux-mirror/main_test.go` - hosts `TestMain`, shared `executeCommand(...)` helpers, and `resetCmdArgs()`, which restores global cobra flag state between tests. New commands or flags must update this reset path so tests do not leak state across subtests.
 - `internal/config/` - YAML config model and validation for `apiVersion: mirror.fluxcd.io/v1alpha1`, `kind: Config`, `artifacts`, `charts`, selector defaults, overwrite behavior, and cosign verification options.
 - `internal/selector/` - tag selection pipeline for OCI artifacts: regex prefilter, semver filter, sort strategy (`semver`, `alphabetical`, `numerical`), then top-N limit.
@@ -35,6 +35,7 @@ Read the [README](README.md) for an overview of the project and its features.
 - `internal/charts/` - Helm chart mirroring to OCI destinations, including version selection, deterministic Helm-OCI publication, drift handling, and dry-run outcomes.
 - `internal/oci/` - OCI client wrapper, auth/keychain setup, transport customization, digest checks, blob copy, Helm artifact helpers, referrers, and cosign verification.
 - `internal/helmrepo/` - HTTP/S and OCI Helm repository access, index/chart resolution, and ambient Helm credential handling.
+- `internal/registryauth/`, `internal/jwkio/`, `internal/keygen/` - per-host registry auth, JWT/JWK loading and signing, and JWK key generation.
 - `internal/flags/` - reusable `pflag.Value` implementations for CLI flags with constrained values, such as output format.
 - `internal/testregistry/` - test helpers for registry-backed mirror tests.
 - `actions/setup/` - composite GitHub Action for installing the CLI on CI runners.
@@ -50,8 +51,10 @@ All development goes through the Makefile - do not invoke `go build` directly, b
 - `make run GO_RUN_ARGS="version -o json"` - build then run the CLI with args
 - `make docker-build` - build the container image
 - `make registry-up` / `make registry-down` - start/stop the local `registry:3` instance used by smoke and integration-style testing
+- `make e2e` - run the podinfo end-to-end test (requires a built binary and local registry)
+- `make govulncheck` - run Go vulnerability checks
 
-CI (`.github/workflows/test.yaml`) runs `make test` and `make lint` and fails if generated formatting or module files leave the working tree dirty, so always run `make test` before committing.
+CI (`.github/workflows/test.yaml`) runs `make test`, `make lint`, `make build`, `make e2e`, and `make docker-build`, then fails if generated formatting or module files leave the working tree dirty.
 
 ### Code Conventions
 
@@ -71,6 +74,7 @@ User-facing changes (flags, commands, config fields, report shape, GitHub Action
 - `README.md` - features list, install, quickstart, CI usage, GitHub Action example, and doc links.
 - `docs/config.md` - YAML config specification, defaults, selectors, overwrite behavior, referrers, and signature verification.
 - `docs/sync.md` - `sync` command reference, config source resolution, authentication, flags, output, outcomes, exit codes, and dry-run behavior.
+- `docs/login.md`, `docs/create.md`, `docs/keygen.md` - auth login, Kubernetes Secret generation, and JWK key generation command references.
 - `actions/setup/README.md` + `actions/setup/action.yaml` - GitHub Action inputs and example workflows.
 - `examples/` - runnable config examples that should stay aligned with supported config fields and defaults.
 
@@ -79,6 +83,7 @@ Apply these rules:
 - New or changed CLI flag: update the flag table in `docs/sync.md` and any relevant examples in `README.md`.
 - New or changed config field: update `internal/config` tests, `docs/config.md`, and examples when appropriate.
 - New command: add or update README command guidance and create a dedicated reference doc under `docs/` if the command has meaningful flags or output.
+- Auth command changes: update `docs/login.md`, `docs/create.md`, or `docs/keygen.md` as applicable.
 - Output or outcome shape change: update `docs/sync.md`, README examples, and tests that assert text/YAML/JSON output.
 - GitHub Action change: when `actions/setup/action.yaml` inputs or behavior change, refresh `actions/setup/README.md`.
 - Registry auth, Helm auth, OIDC/JWT, or cosign verification behavior changes must be documented in the authentication or verification sections, not only in flag help.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,10 @@ on upstream chart repositories.
   copy only what's missing or drifted.
 - **Drift gating** — destination drift (different content under the same tag) is reported
   as a distinct outcome and exit code, so audit pipelines can differentiate "out of date" from "mutated tags".
-- **Ambient auth** — OCI credentials come from `~/.docker/config.json` and the
-  configured credential helpers (ACR, ECR, GAR, etc.); Helm HTTP/S repository
-  credentials come from Helm's `repositories.yaml`. Running `helm repo add` and
-  `docker login` covers source and destination auth. Per-host JWT auth
-  (GitHub/Forgejo OIDC or signed JWKs) is also available via the config's `auth`
-  section — see [config docs](docs/config.md#auth).
+- **Registry auth** — OCI auth supports Docker config and credential helpers,
+  cloud workload identity for ECR/ACR/GAR, and per-host bearer credentials from
+  GitHub/Forgejo OIDC, GCP, Azure, AWS STS, env vars, files, or JWK-signed JWTs.
+  Helm HTTP/S credentials come from Helm's repositories config.
 - **Structured output** — `text` and `yaml`/`json` for downstream
   tooling, plus a verbose mode that streams every blob and manifest digest
   for diagnosing TLS, auth, or push failures.
@@ -181,14 +179,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Flux Mirror CLI
         uses: fluxcd/flux-mirror/actions/setup@main
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Sync Kubernetes SIGs Charts
         run: flux-mirror sync kubernetes-sigs.yaml --no-progress
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Docker
@@ -213,14 +207,14 @@ destination registry credentials from a `Secret` created via
 
 ## Commands
 
-| Command                     | Description                                                      |
-|-----------------------------|------------------------------------------------------------------|
-| `flux-mirror sync [CONFIG]` | Mirror Helm charts and OCI artifacts described by a YAML config. |
-| `flux-mirror login`         | Store configured credentials in the Docker config (or OS keychain). |
+| Command                     | Description                                                                               |
+|-----------------------------|-------------------------------------------------------------------------------------------|
+| `flux-mirror sync [CONFIG]` | Mirror Helm charts and OCI artifacts described by a YAML config.                          |
+| `flux-mirror login`         | Store configured credentials in the Docker config (or OS keychain).                       |
 | `flux-mirror secret <name>` | Create/replace (upsert) a `dockerconfigjson` Kubernetes Secret with per-host credentials. |
-| `flux-mirror keygen`        | Generate an EdDSA JWK pair for JWK-based registry auth.          |
-| `flux-mirror version`       | Print the CLI version.                                           |
-| `flux-mirror completion`    | Generate shell completion for bash, fish, powershell and zsh.    |
+| `flux-mirror keygen`        | Generate an EdDSA JWK pair for JWK-based registry auth.                                   |
+| `flux-mirror version`       | Print the CLI version.                                                                    |
+| `flux-mirror completion`    | Generate shell completion for bash, fish, powershell and zsh.                             |
 
 Run `flux-mirror <command> --help` for the full flag list.
 

--- a/cmd/flux-mirror/progress.go
+++ b/cmd/flux-mirror/progress.go
@@ -46,7 +46,7 @@ func newProgress(out, ttyOut io.Writer, totalEntries int) *progress {
 
 // JobFinished is the OnJobFinished hook for sync.Runner. Safe for
 // concurrent invocation.
-func (p *progress) JobFinished(entry, id, dst string, oc syncpkg.Outcome, err error) {
+func (p *progress) JobFinished(entry, id, dst string, st syncpkg.Status, err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if err != nil {
@@ -56,7 +56,7 @@ func (p *progress) JobFinished(entry, id, dst string, oc syncpkg.Outcome, err er
 		}
 		return
 	}
-	p.emitLocked("✓ %s:%s (%s)\n", entry, id, oc)
+	p.emitLocked("✓ %s:%s (%s)\n", entry, id, st)
 	if dst != "" {
 		p.emitLocked("→ %s\n", dst)
 	}

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -231,7 +231,8 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 			}
 		}
 	default:
-		if err := res.Render(cmd.OutOrStdout(), syncArgs.output.String()); err != nil {
+		report := sync.NewReport("flux-mirror/"+VERSION, time.Now(), res)
+		if err := report.Render(cmd.OutOrStdout(), syncArgs.output.String()); err != nil {
 			return err
 		}
 	}

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -282,8 +282,8 @@ func TestSync_ConfigViaEnv(t *testing.T) {
 
 	out, err := executeCommand([]string{"sync", "--insecure", "-o", "json"})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(out).To(ContainSubstring(`"copied": [`))
-	g.Expect(out).To(ContainSubstring(`"1.0.0"`))
+	g.Expect(out).To(ContainSubstring(`"status": "copied"`))
+	g.Expect(out).To(ContainSubstring(`"tag": "1.0.0"`))
 }
 
 func TestSync_ConfigViaStdin(t *testing.T) {
@@ -297,8 +297,8 @@ func TestSync_ConfigViaStdin(t *testing.T) {
 
 	out, err := executeCommandWithInput([]string{"sync", "-", "--insecure", "-o", "json"}, configBody(src, dst))
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(out).To(ContainSubstring(`"copied": [`))
-	g.Expect(out).To(ContainSubstring(`"1.0.0"`))
+	g.Expect(out).To(ContainSubstring(`"status": "copied"`))
+	g.Expect(out).To(ContainSubstring(`"tag": "1.0.0"`))
 }
 
 func TestSync_ArgOverridesEnv(t *testing.T) {
@@ -363,7 +363,8 @@ func TestSync_DryRun(t *testing.T) {
 
 	out, err := executeCommand([]string{"sync", cfgPath, "--insecure", "--dry-run", "-o", "yaml"})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(out).To(MatchRegexp(`would-copy:\s*\n\s*- 1\.0\.0`))
+	g.Expect(out).To(ContainSubstring("status: would-copy"))
+	g.Expect(out).To(ContainSubstring("tag: 1.0.0"))
 }
 
 func TestSync_BadOutputFormat(t *testing.T) {

--- a/docs/report/README.md
+++ b/docs/report/README.md
@@ -37,28 +37,29 @@ carries no meaning for YAML consumers, so it is dropped in YAML mode.
 Every field is always present (zero when unused) so consumers can rely on a
 stable key set.
 
-| Key              | Description                                                              |
-|------------------|--------------------------------------------------------------------------|
-| `entries`        | Number of config entries processed.                                      |
-| `copied`         | Total tags copied across all entries.                                    |
-| `overwritten`    | Total tags overwritten (drift with `overwrite: true`).                   |
-| `skipped`        | Total tags skipped (already up to date, or deferred by `verify.minAge`). |
-| `drifted`        | Total tags drifted (different digest, `overwrite: false`).               |
-| `wouldCopy`      | Dry-run forecast: tags that would have been copied.                      |
-| `wouldOverwrite` | Dry-run forecast: tags that would have been overwritten.                 |
-| `failed`         | Total failures: tag-level failures plus plan-failed entries.             |
+| Key              | Description                                                                                  |
+|------------------|----------------------------------------------------------------------------------------------|
+| `entries`        | Number of config entries processed.                                                          |
+| `copied`         | Total tags copied across all entries.                                                        |
+| `overwritten`    | Total tags overwritten (drift with `overwrite: true`).                                       |
+| `skipped`        | Total tags skipped (already up to date, or deferred by `verify.minAge`).                     |
+| `drifted`        | Total tags drifted (different digest, `overwrite: false`).                                   |
+| `wouldCopy`      | Dry-run forecast: tags that would have been copied.                                          |
+| `wouldOverwrite` | Dry-run forecast: tags that would have been overwritten.                                     |
+| `failed`         | Total failures: tag-level failures plus plan-failed entries.                                 |
 | `exitCode`       | Semantic exit code: `0` clean, `1` failures, `2` drift. Not affected by `--drift-exit-code`. |
 
 ## Result fields
 
 Each `results[]` entry describes one config entry (an artifact or chart source).
 
-| Key       | Description                                                                                                          |
-|-----------|--------------------------------------------------------------------------------------------------------------------|
-| `name`    | Entry identifier (the source repository/reference).                                                                 |
-| `status`  | Entry-level outcome: `completed` or `failed`.                                                                       |
-| `error`   | Plan-time error message. Present **only** when `status` is `failed`.                                                |
-| `tags[]`  | Per-tag results, in plan order (deterministic). May be empty.                                                       |
+| Key           | Description                                                          |
+|---------------|----------------------------------------------------------------------|
+| `source`      | Source repository/reference being mirrored.                          |
+| `destination` | Destination repository the entry mirrors into.                       |
+| `status`      | Entry-level outcome: `completed` or `failed`.                        |
+| `error`       | Plan-time error message. Present **only** when `status` is `failed`. |
+| `tags[]`      | Per-tag results, in plan order (deterministic). May be empty.        |
 
 The entry `status` disambiguates an empty `tags` array:
 
@@ -70,27 +71,27 @@ problems, not an entry-level failure.
 
 ## Tag fields
 
-| Key              | Description                                                                                              |
-|------------------|--------------------------------------------------------------------------------------------------------|
-| `tag`            | Tag name (artifacts) or chart version (charts).                                                         |
-| `status`         | Per-tag outcome — see [Status](#status-values).                                                         |
-| `digest`         | Source artifact digest, when resolved. Absent on a verify-failed row.                                   |
-| `reason`         | Why a `skipped` tag was skipped — see [Reason](#reason-values). Present **only** on `skipped`.          |
-| `error`          | Error message. Present **only** when `status` is `failed`.                                              |
-| `referrers[]`    | Mirrored sub-artifacts (signatures, SBOMs, attestations). Present only with `includeReferrers`.         |
-| `verification`   | Signature verification metadata. Present only when a signature was confirmed (under `verify:`).         |
+| Key            | Description                                                                                     |
+|----------------|-------------------------------------------------------------------------------------------------|
+| `tag`          | Tag name (artifacts) or chart version (charts).                                                 |
+| `status`       | Per-tag outcome — see [Status](#status-values).                                                 |
+| `digest`       | Source artifact digest, when resolved. Absent on a verify-failed row.                           |
+| `reason`       | Why a `skipped` tag was skipped — see [Reason](#reason-values). Present **only** on `skipped`.  |
+| `error`        | Error message. Present **only** when `status` is `failed`.                                      |
+| `referrers[]`  | Mirrored sub-artifacts (signatures, SBOMs, attestations). Present only with `includeReferrers`. |
+| `verification` | Signature verification metadata. Present only when a signature was confirmed (under `verify:`). |
 
 ### Status values
 
-| Status            | Meaning                                                                          |
-|-------------------|----------------------------------------------------------------------------------|
-| `copied`          | Destination did not have it; mirrored from source.                               |
-| `overwritten`     | Destination had a different digest; replaced (`overwrite: true`).                |
-| `skipped`         | Nothing copied; see `reason`.                                                     |
-| `drifted`         | Destination has a different digest, `overwrite: false` — left alone.             |
-| `would-copy`      | Dry-run: would have been copied.                                                 |
-| `would-overwrite` | Dry-run: would have been overwritten.                                            |
-| `failed`          | The operation errored; see `error`.                                              |
+| Status            | Meaning                                                              |
+|-------------------|----------------------------------------------------------------------|
+| `copied`          | Destination did not have it; mirrored from source.                   |
+| `overwritten`     | Destination had a different digest; replaced (`overwrite: true`).    |
+| `skipped`         | Nothing copied; see `reason`.                                        |
+| `drifted`         | Destination has a different digest, `overwrite: false` — left alone. |
+| `would-copy`      | Dry-run: would have been copied.                                     |
+| `would-overwrite` | Dry-run: would have been overwritten.                                |
+| `failed`          | The operation errored; see `error`.                                  |
 
 ### Reason values
 
@@ -106,12 +107,12 @@ problems, not an entry-level failure.
 Each `referrers[]` entry describes one referrer (e.g. a cosign signature bundle, an
 SBOM, or an attestation) mirrored alongside its parent tag.
 
-| Key            | Description                                                       |
-|----------------|-----------------------------------------------------------------|
-| `digest`       | Referrer manifest digest.                                       |
+| Key            | Description                                                    |
+|----------------|----------------------------------------------------------------|
+| `digest`       | Referrer manifest digest.                                      |
 | `artifactType` | The referrer manifest's `artifactType`, when set.              |
-| `status`       | Same [Status](#status-values) enum as a tag.                    |
-| `reason`       | Present **only** on `skipped` (same [Reason](#reason-values)).  |
+| `status`       | Same [Status](#status-values) enum as a tag.                   |
+| `reason`       | Present **only** on `skipped` (same [Reason](#reason-values)). |
 
 Referrers are reported for any tag whose mirror flow reached the referrer step — every
 status except `failed` (the tag copy errored first) and the `signature-too-new` skip
@@ -123,14 +124,14 @@ with `would-copy` / `would-overwrite` / `skipped` statuses.
 Present only when a signature was confirmed (the entry has a `verify:` block). Only
 `provider` is guaranteed; the rest is best-effort.
 
-| Key              | Description                                                                                       |
-|------------------|--------------------------------------------------------------------------------------------------|
-| `provider`       | Verification provider, e.g. `cosign`.                                                             |
-| `issuer`         | Matched OIDC issuer from the signing certificate.                                                 |
-| `identity`       | Matched certificate identity (subject alternative name).                                          |
+| Key              | Description                                                                                          |
+|------------------|------------------------------------------------------------------------------------------------------|
+| `provider`       | Verification provider, e.g. `cosign`.                                                                |
+| `issuer`         | Matched OIDC issuer from the signing certificate.                                                    |
+| `identity`       | Matched certificate identity (subject alternative name).                                             |
 | `integratedTime` | Transparency-log integration time (RFC 3339). Present only when the bundle carries a Tlog timestamp. |
-| `age`            | Signature age, as a Go duration string. Present only on a `signature-too-new` skip.               |
-| `minAge`         | Configured `verify.minAge`, as a Go duration string. Present only on a `signature-too-new` skip.  |
+| `age`            | Signature age, as a Go duration string. Present only on a `signature-too-new` skip.                  |
+| `minAge`         | Configured `verify.minAge`, as a Go duration string. Present only on a `signature-too-new` skip.     |
 
 A verify *failure* (bad/missing signature, OIDC mismatch) is not a `verification` block:
 it surfaces as a `status: "failed"` tag row carrying the verify `error`, with no
@@ -161,8 +162,8 @@ second entry failed at plan time because the source repository does not exist.
   "$schema": "https://raw.githubusercontent.com/fluxcd/flux-mirror/main/docs/report/schema-1.0.0.json",
   "report": {
     "reporter": "flux-mirror/v0.1.0",
-    "timestamp": "2026-06-06T19:23:05Z",
-    "durationMs": 17217,
+    "timestamp": "2026-06-06T20:12:25Z",
+    "durationMs": 16724,
     "summary": {
       "entries": 2,
       "copied": 1,
@@ -176,7 +177,8 @@ second entry failed at plan time because the source repository does not exist.
     },
     "results": [
       {
-        "name": "docker.io/stefanprodan/podinfo",
+        "source": "docker.io/stefanprodan/podinfo",
+        "destination": "localhost:5050/podinfo",
         "status": "completed",
         "tags": [
           {
@@ -189,7 +191,7 @@ second entry failed at plan time because the source repository does not exist.
               "issuer": "https://token.actions.githubusercontent.com",
               "identity": "https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.13.0",
               "integratedTime": "2026-06-04T20:59:02Z",
-              "age": "46h23m50s",
+              "age": "47h13m11s",
               "minAge": "48h0m0s"
             }
           },
@@ -214,7 +216,8 @@ second entry failed at plan time because the source repository does not exist.
         ]
       },
       {
-        "name": "docker.io/library/flux-mirror-nonexistent-zzz",
+        "source": "docker.io/library/flux-mirror-nonexistent-zzz",
+        "destination": "localhost:5050/nonexistent",
         "status": "failed",
         "error": "list tags docker.io/library/flux-mirror-nonexistent-zzz: GET https://index.docker.io/v2/library/flux-mirror-nonexistent-zzz/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/flux-mirror-nonexistent-zzz Type:repository]]",
         "tags": []

--- a/docs/report/README.md
+++ b/docs/report/README.md
@@ -1,0 +1,225 @@
+# flux-mirror sync report
+
+The `flux-mirror sync` command can emit a structured report of the mirror
+results by setting `--output` to `json` or `yaml`. The envelope shape is
+versioned and documented by the JSON Schema in
+[`schema-1.0.0.json`](./schema-1.0.0.json).
+
+## Usage
+
+```shell
+flux-mirror sync config.yaml -o json
+```
+
+Structured output always emits every entry regardless of `--verbose`.
+Filtering belongs downstream (`jq`, `yq`). The process exit code still
+reflects whether any tag failed or drifted (see [exit codes](../sync.md#exit-codes)).
+
+## Envelope
+
+Every report is wrapped in a top-level envelope:
+
+| Key                 | Description                                                  |
+|---------------------|--------------------------------------------------------------|
+| `version`           | Wire format version. Currently `"1.0.0"`.                    |
+| `$schema`           | URL of the JSON Schema describing the envelope. JSON only.   |
+| `report.reporter`   | Identity of the producer, e.g. `flux-mirror/v0.1.0`.         |
+| `report.timestamp`  | RFC 3339 UTC timestamp of the run.                           |
+| `report.durationMs` | Total wall time of the run, in milliseconds.                 |
+| `report.summary`    | Aggregate counts across all entries (see below).             |
+| `report.results[]`  | One entry per config entry, in config order.                 |
+
+The `$schema` key is JSON-only — it points at a JSON Schema document and
+carries no meaning for YAML consumers, so it is dropped in YAML mode.
+
+## Summary fields
+
+Every field is always present (zero when unused) so consumers can rely on a
+stable key set.
+
+| Key              | Description                                                              |
+|------------------|--------------------------------------------------------------------------|
+| `entries`        | Number of config entries processed.                                      |
+| `copied`         | Total tags copied across all entries.                                    |
+| `overwritten`    | Total tags overwritten (drift with `overwrite: true`).                   |
+| `skipped`        | Total tags skipped (already up to date, or deferred by `verify.minAge`). |
+| `drifted`        | Total tags drifted (different digest, `overwrite: false`).               |
+| `wouldCopy`      | Dry-run forecast: tags that would have been copied.                      |
+| `wouldOverwrite` | Dry-run forecast: tags that would have been overwritten.                 |
+| `failed`         | Total failures: tag-level failures plus plan-failed entries.             |
+| `exitCode`       | Semantic exit code: `0` clean, `1` failures, `2` drift. Not affected by `--drift-exit-code`. |
+
+## Result fields
+
+Each `results[]` entry describes one config entry (an artifact or chart source).
+
+| Key       | Description                                                                                                          |
+|-----------|--------------------------------------------------------------------------------------------------------------------|
+| `name`    | Entry identifier (the source repository/reference).                                                                 |
+| `status`  | Entry-level outcome: `completed` or `failed`.                                                                       |
+| `error`   | Plan-time error message. Present **only** when `status` is `failed`.                                                |
+| `tags[]`  | Per-tag results, in plan order (deterministic). May be empty.                                                       |
+
+The entry `status` disambiguates an empty `tags` array:
+
+- `completed` + `[]` → the entry was planned and run, but nothing matched the selector.
+- `failed` + `[]` (+ `error`) → the entry could not be planned (e.g. tag listing failed).
+
+A `completed` entry can still contain tag-level `failed` rows — those are per-tag
+problems, not an entry-level failure.
+
+## Tag fields
+
+| Key              | Description                                                                                              |
+|------------------|--------------------------------------------------------------------------------------------------------|
+| `tag`            | Tag name (artifacts) or chart version (charts).                                                         |
+| `status`         | Per-tag outcome — see [Status](#status-values).                                                         |
+| `digest`         | Source artifact digest, when resolved. Absent on a verify-failed row.                                   |
+| `reason`         | Why a `skipped` tag was skipped — see [Reason](#reason-values). Present **only** on `skipped`.          |
+| `error`          | Error message. Present **only** when `status` is `failed`.                                              |
+| `referrers[]`    | Mirrored sub-artifacts (signatures, SBOMs, attestations). Present only with `includeReferrers`.         |
+| `verification`   | Signature verification metadata. Present only when a signature was confirmed (under `verify:`).         |
+
+### Status values
+
+| Status            | Meaning                                                                          |
+|-------------------|----------------------------------------------------------------------------------|
+| `copied`          | Destination did not have it; mirrored from source.                               |
+| `overwritten`     | Destination had a different digest; replaced (`overwrite: true`).                |
+| `skipped`         | Nothing copied; see `reason`.                                                     |
+| `drifted`         | Destination has a different digest, `overwrite: false` — left alone.             |
+| `would-copy`      | Dry-run: would have been copied.                                                 |
+| `would-overwrite` | Dry-run: would have been overwritten.                                            |
+| `failed`          | The operation errored; see `error`.                                              |
+
+### Reason values
+
+`reason` is always present on a `skipped` status (tag or referrer) and absent otherwise.
+
+| Reason              | Meaning                                                                       |
+|---------------------|-------------------------------------------------------------------------------|
+| `up-to-date`        | Destination already has the same digest.                                      |
+| `signature-too-new` | A valid signature was deferred because it is younger than `verify.minAge`.    |
+
+## Referrer fields
+
+Each `referrers[]` entry describes one referrer (e.g. a cosign signature bundle, an
+SBOM, or an attestation) mirrored alongside its parent tag.
+
+| Key            | Description                                                       |
+|----------------|-----------------------------------------------------------------|
+| `digest`       | Referrer manifest digest.                                       |
+| `artifactType` | The referrer manifest's `artifactType`, when set.              |
+| `status`       | Same [Status](#status-values) enum as a tag.                    |
+| `reason`       | Present **only** on `skipped` (same [Reason](#reason-values)).  |
+
+Referrers are reported for any tag whose mirror flow reached the referrer step — every
+status except `failed` (the tag copy errored first) and the `signature-too-new` skip
+(deferred without mirroring). In `--dry-run`, referrers are still evaluated and reported
+with `would-copy` / `would-overwrite` / `skipped` statuses.
+
+## Verification fields
+
+Present only when a signature was confirmed (the entry has a `verify:` block). Only
+`provider` is guaranteed; the rest is best-effort.
+
+| Key              | Description                                                                                       |
+|------------------|--------------------------------------------------------------------------------------------------|
+| `provider`       | Verification provider, e.g. `cosign`.                                                             |
+| `issuer`         | Matched OIDC issuer from the signing certificate.                                                 |
+| `identity`       | Matched certificate identity (subject alternative name).                                          |
+| `integratedTime` | Transparency-log integration time (RFC 3339). Present only when the bundle carries a Tlog timestamp. |
+| `age`            | Signature age, as a Go duration string. Present only on a `signature-too-new` skip.               |
+| `minAge`         | Configured `verify.minAge`, as a Go duration string. Present only on a `signature-too-new` skip.  |
+
+A verify *failure* (bad/missing signature, OIDC mismatch) is not a `verification` block:
+it surfaces as a `status: "failed"` tag row carrying the verify `error`, with no
+`verification` and no `digest`. Verification runs at plan time, so the first verify
+failure stops the entry (tags verified before it still run); the entry itself stays
+`status: "completed"`. A real verify-failed row (the configured OIDC subject regex
+did not match the signed identity):
+
+```json
+{
+  "tag": "6.13.0",
+  "status": "failed",
+  "error": "verify docker.io/stefanprodan/podinfo:6.13.0: signature verification failed: failed to verify certificate identity: no matching CertificateIdentity found, last error: expected SAN value to match regex \"^https://github\\.com/example/.*$\", got \"https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.13.0\""
+}
+```
+
+## Example
+
+A report from `flux-mirror sync … -o json` against a config with cosign
+verification (`minAge: 48h`) and `includeReferrers: true`. The first entry
+completed: tag `6.13.0` was deferred because its signature is younger than
+`minAge`, while `6.12.0` was copied along with its cosign signature bundle. The
+second entry failed at plan time because the source repository does not exist.
+
+```json
+{
+  "version": "1.0.0",
+  "$schema": "https://raw.githubusercontent.com/fluxcd/flux-mirror/main/docs/report/schema-1.0.0.json",
+  "report": {
+    "reporter": "flux-mirror/v0.1.0",
+    "timestamp": "2026-06-06T19:23:05Z",
+    "durationMs": 17217,
+    "summary": {
+      "entries": 2,
+      "copied": 1,
+      "overwritten": 0,
+      "skipped": 1,
+      "drifted": 0,
+      "wouldCopy": 0,
+      "wouldOverwrite": 0,
+      "failed": 1,
+      "exitCode": 1
+    },
+    "results": [
+      {
+        "name": "docker.io/stefanprodan/podinfo",
+        "status": "completed",
+        "tags": [
+          {
+            "tag": "6.13.0",
+            "status": "skipped",
+            "digest": "sha256:7bdd8cc80b64377b05f5c0a51604c028ed6adea4beaca2e766b9325efa52916c",
+            "reason": "signature-too-new",
+            "verification": {
+              "provider": "cosign",
+              "issuer": "https://token.actions.githubusercontent.com",
+              "identity": "https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.13.0",
+              "integratedTime": "2026-06-04T20:59:02Z",
+              "age": "46h23m50s",
+              "minAge": "48h0m0s"
+            }
+          },
+          {
+            "tag": "6.12.0",
+            "status": "copied",
+            "digest": "sha256:453e2238f70c00dfba6803ddb99a4bb86982ee549f7273f43f90ac58f0714a81",
+            "referrers": [
+              {
+                "digest": "sha256:5892f840c5013230cd0b63fdd5076dd9fe3224a31bd3ebae5c723e3632100b0f",
+                "artifactType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+                "status": "copied"
+              }
+            ],
+            "verification": {
+              "provider": "cosign",
+              "issuer": "https://token.actions.githubusercontent.com",
+              "identity": "https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.12.0",
+              "integratedTime": "2026-05-20T10:16:39Z"
+            }
+          }
+        ]
+      },
+      {
+        "name": "docker.io/library/flux-mirror-nonexistent-zzz",
+        "status": "failed",
+        "error": "list tags docker.io/library/flux-mirror-nonexistent-zzz: GET https://index.docker.io/v2/library/flux-mirror-nonexistent-zzz/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/flux-mirror-nonexistent-zzz Type:repository]]",
+        "tags": []
+      }
+    ]
+  }
+}
+```

--- a/docs/report/schema-1.0.0.json
+++ b/docs/report/schema-1.0.0.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/fluxcd/flux-mirror/main/docs/report/schema-1.0.0.json",
+  "title": "flux-mirror sync report",
+  "description": "Structured report emitted by `flux-mirror sync --output json|yaml`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "report"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reporter", "timestamp", "durationMs", "summary", "results"],
+      "properties": {
+        "reporter": {
+          "type": "string",
+          "pattern": "^flux-mirror/"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "entries",
+            "copied",
+            "overwritten",
+            "skipped",
+            "drifted",
+            "wouldCopy",
+            "wouldOverwrite",
+            "failed",
+            "exitCode"
+          ],
+          "properties": {
+            "entries":        { "type": "integer", "minimum": 0 },
+            "copied":         { "type": "integer", "minimum": 0 },
+            "overwritten":    { "type": "integer", "minimum": 0 },
+            "skipped":        { "type": "integer", "minimum": 0 },
+            "drifted":        { "type": "integer", "minimum": 0 },
+            "wouldCopy":      { "type": "integer", "minimum": 0 },
+            "wouldOverwrite": { "type": "integer", "minimum": 0 },
+            "failed":         { "type": "integer", "minimum": 0 },
+            "exitCode":       { "type": "integer", "enum": [0, 1, 2] }
+          }
+        },
+        "results": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/result" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "status": {
+      "description": "Outcome of mirroring one tag or referrer.",
+      "type": "string",
+      "enum": [
+        "copied",
+        "overwritten",
+        "skipped",
+        "drifted",
+        "would-copy",
+        "would-overwrite",
+        "failed"
+      ]
+    },
+    "reason": {
+      "description": "Why a skipped tag or referrer was skipped. Always present on a skipped status.",
+      "type": "string",
+      "enum": ["up-to-date", "signature-too-new"]
+    },
+    "result": {
+      "description": "One config entry (artifact or chart source).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "tags"],
+      "properties": {
+        "name": {
+          "description": "Entry identifier (the source repository/reference).",
+          "type": "string"
+        },
+        "status": {
+          "description": "Entry-level outcome. 'failed' means the entry could not be planned (e.g. tag listing failed) and 'tags' is empty; 'completed' means it was planned and run (its 'tags' may still contain failed rows, or be empty when nothing matched).",
+          "type": "string",
+          "enum": ["completed", "failed"]
+        },
+        "error": {
+          "description": "Plan-time error message. Present only when status is 'failed'.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Per-tag results, in plan order.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/tag" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "failed" } } },
+          "then": { "required": ["error"] },
+          "else": { "not": { "required": ["error"] } }
+        }
+      ]
+    },
+    "tag": {
+      "description": "Result of mirroring one tag (artifact tag or chart version).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tag", "status"],
+      "properties": {
+        "tag": {
+          "description": "Tag name (artifacts) or chart version (charts).",
+          "type": "string"
+        },
+        "status": { "$ref": "#/$defs/status" },
+        "digest": {
+          "description": "Source artifact digest, when resolved. Absent on a verify-failed row.",
+          "type": "string"
+        },
+        "reason": { "$ref": "#/$defs/reason" },
+        "error": {
+          "description": "Error message. Present only when status is 'failed'.",
+          "type": "string"
+        },
+        "referrers": {
+          "description": "Mirrored sub-artifacts (cosign signatures, SBOMs, attestations). Present only with includeReferrers.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/referrer" }
+        },
+        "verification": { "$ref": "#/$defs/verification" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "skipped" } }, "required": ["status"] },
+          "then": { "required": ["reason"] },
+          "else": { "not": { "required": ["reason"] } }
+        },
+        {
+          "if": { "properties": { "status": { "const": "failed" } }, "required": ["status"] },
+          "then": { "required": ["error"] },
+          "else": { "not": { "required": ["error"] } }
+        }
+      ]
+    },
+    "referrer": {
+      "description": "Result of mirroring one referrer of a tag.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["digest", "status"],
+      "properties": {
+        "digest": {
+          "description": "Referrer manifest digest.",
+          "type": "string"
+        },
+        "artifactType": {
+          "description": "The referrer manifest's artifactType, when set.",
+          "type": "string"
+        },
+        "status": { "$ref": "#/$defs/status" },
+        "reason": { "$ref": "#/$defs/reason" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "skipped" } }, "required": ["status"] },
+          "then": { "required": ["reason"] },
+          "else": { "not": { "required": ["reason"] } }
+        }
+      ]
+    },
+    "verification": {
+      "description": "Signature verification metadata. Present only when a signature was confirmed (verify: configured). Only 'provider' is guaranteed; the rest is best-effort.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider"],
+      "properties": {
+        "provider": {
+          "description": "Verification provider, e.g. 'cosign'.",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "Matched OIDC issuer from the signing certificate.",
+          "type": "string"
+        },
+        "identity": {
+          "description": "Matched certificate identity (subject alternative name).",
+          "type": "string"
+        },
+        "integratedTime": {
+          "description": "Transparency-log integration time (RFC 3339). Present only when the bundle carries a verified Tlog timestamp.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "age": {
+          "description": "Signature age at evaluation time, as a Go duration string. Present only on a signature-too-new skip.",
+          "type": "string"
+        },
+        "minAge": {
+          "description": "Configured verify.minAge, as a Go duration string. Present only on a signature-too-new skip.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/report/schema-1.0.0.json
+++ b/docs/report/schema-1.0.0.json
@@ -88,10 +88,14 @@
       "description": "One config entry (artifact or chart source).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "status", "tags"],
+      "required": ["source", "destination", "status", "tags"],
       "properties": {
-        "name": {
-          "description": "Entry identifier (the source repository/reference).",
+        "source": {
+          "description": "Source repository/reference being mirrored.",
+          "type": "string"
+        },
+        "destination": {
+          "description": "Destination repository the entry mirrors into.",
           "type": "string"
         },
         "status": {

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -50,7 +50,7 @@ repository credentials automatically.
 
 | Flag                            | Default | Description                                                                                                                                        |
 |---------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-o, --output text\|yaml\|json` | `text`  | Output format. `text` is human-friendly; `yaml` and `json` print the structured `Result` to stdout.                                                |
+| `-o, --output text\|yaml\|json` | `text`  | Output format. `text` is human-friendly; `yaml` and `json` print the structured [sync report](./report/README.md) to stdout.                       |
 | `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel within a single config entry. Entries themselves are processed sequentially.                  |
 | `--retries N`                   | `3`     | Maximum number of retry attempts per job, bounded by `--timeout`.                                                                                  |
 | `--overwrite`                   | `false` | Force `overwrite: true` on every entry, regardless of per-entry config. See [Overwrite Behavior](./config.md#overwrite-behavior).                  |
@@ -91,36 +91,69 @@ and registry-side warning is logged. Reach for this when diagnosing TLS, auth, m
 2026/05/13 09:00:00 existing blob: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
 2026/05/13 09:00:00 localhost:5050/bar:1.0: digest: sha256:455d6a04fe43df4a93b40e1f92d65b2a9befaa0348e5a461295d961161ebf475 size: 829
 2026/05/13 09:00:00 updating fallback tag sha256-455d6a04... with new referrer
-2026/05/13 09:00:01 tag done src=ghcr.io/foo/bar:1.0 outcome=copied elapsed=812ms
+2026/05/13 09:00:01 tag done src=ghcr.io/foo/bar:1.0 status=copied elapsed=812ms
 …
 2026/05/13 09:00:04 sync complete entries=3 copied=1 overwritten=0 skipped=1 drifted=0 failed=1 duration=4.213s
 ```
 
 ### Structured output
 
-`-o yaml` and `-o json` print the full `Result` to stdout — entries with their per-outcome tag lists and any failures
-Suitable for piping into another tool.
+`-o yaml` and `-o json` print a versioned report to stdout: a top-level envelope
+(`version`, `$schema`, `report`) wrapping run metadata (`reporter`, `timestamp`,
+`durationMs`), an aggregate `summary` of per-status tag counts, and `results[]`
+where each entry carries a `status` (`completed`/`failed`) and a `tags[]` array
+of per-tag rows. Every row has a `status` and, when known, a source `digest`;
+skipped rows always carry a `reason`; verified rows carry a `verification` block;
+and, with `includeReferrers: true`, a `referrers[]` array. The envelope is
+documented by the [sync report schema](./report/README.md).
 
 ```bash
-flux-mirror sync config.yaml -o json | jq '.entries[].outcomes.copied'
+# Status of every tag, per entry
+flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | {tag, status}'
+
+# Tags that were copied
+flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | select(.status == "copied") | .tag'
+
+# Verified identities
+flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | select(.verification) | {tag, identity: .verification.identity}'
+
+# Aggregate counts
+flux-mirror sync config.yaml -o json | jq '.report.summary'
 ```
 
-## Outcomes
+## Status
 
-Each tag job lands in exactly one of these buckets:
+Each tag row (and each referrer row) lands in exactly one of these statuses:
 
-| Outcome           | Meaning                                                                                           |
+| Status            | Meaning                                                                                           |
 |-------------------|---------------------------------------------------------------------------------------------------|
 | `copied`          | Destination did not have the tag; mirrored from source.                                           |
 | `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                       |
-| `skipped`         | Nothing was copied: destination already matched, or `verify.minAge` deferred a too-new signature. |
+| `skipped`         | Nothing was copied; the row's `reason` says why (see below).                                       |
 | `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary.     |
 | `would-copy`      | Dry-run forecast: would have been copied.                                                         |
 | `would-overwrite` | Dry-run forecast: would have been overwritten.                                                    |
+| `failed`          | The operation errored; the row's `error` carries the message.                                     |
 
-Plan-time failures (e.g., source registry rejected a `ListTags`, or cosign
-verification failed for a selected source tag) are reported as a single
-`✗ <entry> — plan failed: <err>` line and counted toward `failed`.
+A `skipped` row always carries a `reason`: `up-to-date` (the destination already
+has the same digest) or `signature-too-new` (a valid signature was deferred by
+`verify.minAge`).
+
+A failed signature verification (bad/missing signature, OIDC mismatch) is recorded
+as a `failed` tag row carrying the verify error; verification runs at plan time, so
+the first failure stops the entry (tags verified before it still run) while the
+entry itself stays `completed`. A true plan-time failure (e.g. the source registry
+rejected a `ListTags`) surfaces as an entry with `status: "failed"`, an `error`, and
+an empty `tags` array, and is reported live as a `✗ <entry> — plan failed: <err>`
+line. Both kinds count toward `failed`.
+
+### Referrers
+
+When an entry sets `includeReferrers: true`, each tag row gains a `referrers[]`
+array — one row per mirrored sub-artifact (cosign signature bundle, SBOM,
+attestation), each with its own `digest`, `artifactType`, `status`, and (when
+skipped) `reason`. Referrers are evaluated in `--dry-run` too, reported with
+`would-copy` / `would-overwrite` / `skipped` statuses without writing.
 
 ## Exit codes
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -27,24 +27,29 @@ FLUX_MIRROR_CONFIG=examples/podinfo.yaml flux-mirror sync
 
 ## Authentication
 
-OCI registry auth is read from the ambient Docker config:
+`sync` authenticates OCI registry requests (`artifacts` and `oci://` Helm
+sources) per registry host:
 
-- `~/.docker/config.json`, or the `DOCKER_CONFIG` env var if set.
-- Any configured credential helpers (e.g., `docker-credential-osxkeychain`, `docker-credential-ecr-login`, `docker-credential-gcloud`).
+1. Hosts listed in [`auth.hosts`](./config.md#auth) use their configured auth:
+   - `provider: ecr|acr|gar` obtains registry credentials from the cloud
+     provider's workload identity.
+   - `credential` resolves a per-host secret from GitHub/Forgejo OIDC, GCP,
+     Azure, AWS STS, `fromEnv`, `fromPath`, or `jwkPath`. With no `username`,
+     it is sent directly as `Authorization: Bearer`. With `username`, it is used
+     as the password in the standard registry auth challenge,
+     which covers registries like Docker Hub, GHCR, and Quay without a prior `docker login`.
+2. Hosts not listed in `auth.hosts` use the Docker config and credential helpers from
+   `~/.docker/config.json`, or the `DOCKER_CONFIG` env var if set.
 
-Log in once with `docker login`, `oras login`, etc. and `flux-mirror` picks up the credentials.
-
-Hosts listed in the config's [`auth`](./config.md#auth) section authenticate with a
-per-host JWT instead; use `auth` or ambient credentials for a given host, not both.
-
-Helm HTTP/S repository auth is read from the ambient Helm repositories config:
+Helm HTTP/S repository auth is separate from OCI auth and always comes from the
+ambient Helm repositories config:
 
 - Helm's default `repositories.yaml` path, or the `HELM_REPOSITORY_CONFIG` env var if set.
 - `username` / `password`, `certFile`, `keyFile`, `caFile`, `insecure_skip_tls_verify`, and
   `pass_credentials_all` are honored.
 
-Log in or add repositories with `helm repo add` and `flux-mirror` picks up matching HTTP/S
-repository credentials automatically.
+Log in or add repositories with `helm repo add` and `flux-mirror` picks up
+matching HTTP/S repository credentials automatically.
 
 ## Flags
 
@@ -125,15 +130,15 @@ flux-mirror sync config.yaml -o json | jq '.report.summary'
 
 Each tag row (and each referrer row) lands in exactly one of these statuses:
 
-| Status            | Meaning                                                                                           |
-|-------------------|---------------------------------------------------------------------------------------------------|
-| `copied`          | Destination did not have the tag; mirrored from source.                                           |
-| `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                       |
-| `skipped`         | Nothing was copied; the row's `reason` says why (see below).                                       |
-| `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary.     |
-| `would-copy`      | Dry-run forecast: would have been copied.                                                         |
-| `would-overwrite` | Dry-run forecast: would have been overwritten.                                                    |
-| `failed`          | The operation errored; the row's `error` carries the message.                                     |
+| Status            | Meaning                                                                                       |
+|-------------------|-----------------------------------------------------------------------------------------------|
+| `copied`          | Destination did not have the tag; mirrored from source.                                       |
+| `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                   |
+| `skipped`         | Nothing was copied; the row's `reason` says why (see below).                                  |
+| `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary. |
+| `would-copy`      | Dry-run forecast: would have been copied.                                                     |
+| `would-overwrite` | Dry-run forecast: would have been overwritten.                                                |
+| `failed`          | The operation errored; the row's `error` carries the message.                                 |
 
 A `skipped` row always carries a `reason`: `up-to-date` (the destination already
 has the same digest) or `signature-too-new` (a valid signature was deferred by
@@ -245,7 +250,7 @@ consuming `HelmRelease.spec.values` to point at the mirror.
 ### Preview without writing
 
 ```bash
-flux-mirror sync config.yaml --dry-run -o yaml
+flux-mirror sync config.yaml --dry-run -o json
 ```
 
 ### Force-resync drifted tags

--- a/internal/artifacts/mirror.go
+++ b/internal/artifacts/mirror.go
@@ -71,7 +71,7 @@ type tagJob struct {
 	tag          string
 	src          string
 	dst          string
-	srcDigest    string // pre-fetched only when refs were snapshotted; otherwise ""
+	srcDigest    string // pre-fetched when verified or when refs were snapshotted; otherwise ""
 	refs         []oci.Referrer
 	overwrite    bool
 	verification *sync.Verification // confirmed at plan time when entry.verify is set
@@ -150,6 +150,10 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 				})
 				break
 			}
+			if info == nil || info.Digest == "" {
+				return plan, fmt.Errorf("verify %s: verifier returned no digest", job.src)
+			}
+			job.srcDigest = info.Digest
 			job.verification = toVerification(info)
 		}
 
@@ -158,15 +162,17 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 		// runner does. Without this, a transient failure mid-mirror could
 		// re-list and mix referrers from before/after a publish.
 		if m.entry.IncludeReferrers {
-			srcDigest, err := m.client.Digest(ctx, job.src)
-			if err != nil {
-				return plan, fmt.Errorf("resolve digest for referrers (%s): %w", job.src, err)
+			if job.srcDigest == "" {
+				srcDigest, err := m.client.Digest(ctx, job.src)
+				if err != nil {
+					return plan, fmt.Errorf("resolve digest for referrers (%s): %w", job.src, err)
+				}
+				job.srcDigest = srcDigest
 			}
-			refs, err := m.client.SnapshotReferrers(ctx, m.entry.Source, srcDigest)
+			refs, err := m.client.SnapshotReferrers(ctx, m.entry.Source, job.srcDigest)
 			if err != nil {
 				return plan, fmt.Errorf("snapshot referrers for %s: %w", job.src, err)
 			}
-			job.srcDigest = srcDigest
 			job.refs = refs
 		}
 
@@ -186,14 +192,18 @@ func (m *mirror) runTag(ctx context.Context, j tagJob) (sync.JobResult, error) {
 	start := time.Now()
 	m.opts.Logger.Info("mirroring tag", "src", j.src, "dst", j.dst)
 
-	// When refs were snapshotted at plan time, j.srcDigest is also known —
-	// skip the redundant src-side Digest call.
+	// When verification or referrer snapshotting resolved the source digest at
+	// plan time, use that digest as the source of truth.
 	cmp, err := m.compareTag(ctx, j.src, j.dst, j.srcDigest)
 	if err != nil {
 		return sync.JobResult{}, err
 	}
 
-	st, reason, err := m.applyOutcome(ctx, j.src, j.dst, cmp, j.overwrite, m.opts.CopyJobs)
+	copySrc := j.src
+	if j.srcDigest != "" {
+		copySrc = m.entry.Source + "@" + j.srcDigest
+	}
+	st, reason, err := m.applyOutcome(ctx, copySrc, j.dst, cmp, j.overwrite, m.opts.CopyJobs)
 	if err != nil {
 		// Compare resolved the source digest before the copy failed — keep it
 		// on the failed row.

--- a/internal/artifacts/mirror.go
+++ b/internal/artifacts/mirror.go
@@ -78,7 +78,7 @@ type tagJob struct {
 }
 
 func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
-	plan := sync.Plan{Name: m.entry.Source}
+	plan := sync.Plan{Source: m.entry.Source, Destination: m.entry.Destination}
 
 	tags, err := m.client.ListTags(ctx, m.entry.Source)
 	if err != nil {

--- a/internal/artifacts/mirror.go
+++ b/internal/artifacts/mirror.go
@@ -36,9 +36,12 @@ type Options struct {
 	Verifier Verifier
 }
 
-// Verifier checks a selected source reference before it is mirrored.
+// Verifier checks a selected source reference before it is mirrored. On
+// success it returns the confirmed signature metadata so the report can record
+// the verified identity; a *oci.SignatureTooNewError is returned alongside the
+// info when the signature is valid but younger than the configured minAge.
 type Verifier interface {
-	Verify(ctx context.Context, ref string, cfg config.ArtifactVerification) error
+	Verify(ctx context.Context, ref string, cfg config.ArtifactVerification) (*oci.VerificationInfo, error)
 }
 
 // New builds an EntryMirror for the given artifact entry.
@@ -65,12 +68,13 @@ type mirror struct {
 // time. Pulling these into a struct keeps runTag's signature compact and
 // makes the "captured at plan time" relationship explicit.
 type tagJob struct {
-	tag       string
-	src       string
-	dst       string
-	srcDigest string // pre-fetched only when refs were snapshotted; otherwise ""
-	refs      []oci.Referrer
-	overwrite bool
+	tag          string
+	src          string
+	dst          string
+	srcDigest    string // pre-fetched only when refs were snapshotted; otherwise ""
+	refs         []oci.Referrer
+	overwrite    bool
+	verification *sync.Verification // confirmed at plan time when entry.verify is set
 }
 
 func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
@@ -102,7 +106,8 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 		}
 
 		if m.entry.Verify != nil {
-			if err := m.opts.Verifier.Verify(ctx, job.src, *m.entry.Verify); err != nil {
+			info, err := m.opts.Verifier.Verify(ctx, job.src, *m.entry.Verify)
+			if err != nil {
 				var tooNew *oci.SignatureTooNewError
 				if errors.As(err, &tooNew) {
 					m.opts.Logger.Info("signature too new; skipping tag",
@@ -110,17 +115,42 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 						"integrated_time", tooNew.IntegratedTime.Format(time.RFC3339),
 						"age", tooNew.Age.Round(time.Second),
 						"min_age", tooNew.MinAge)
+					ver := toVerification(info)
+					if ver == nil {
+						ver = &sync.Verification{}
+					}
+					ver.Age = tooNew.Age.Round(time.Second).String()
+					ver.MinAge = tooNew.MinAge.String()
+					skipDigest := ""
+					if info != nil {
+						skipDigest = info.Digest
+					}
 					plan.Jobs = append(plan.Jobs, sync.Job{
-						ID:  tag,
-						Dst: job.dst,
-						Run: func(context.Context) (sync.Outcome, error) {
-							return sync.OutcomeSkipped, nil
+						ID:           tag,
+						Dst:          job.dst,
+						Verification: ver,
+						Run: func(context.Context) (sync.JobResult, error) {
+							return sync.JobResult{
+								Status: sync.StatusSkipped,
+								Reason: sync.ReasonSignatureTooNew,
+								Digest: skipDigest,
+							}, nil
 						},
 					})
 					continue
 				}
-				return plan, fmt.Errorf("verify %s: %w", job.src, err)
+				// Any other verify failure becomes a failed tag row carrying the
+				// error; planning stops after it (tags verified earlier still
+				// run, later tags are not attempted). Unlike a plan-time error,
+				// this keeps the entry status "completed".
+				plan.Jobs = append(plan.Jobs, sync.Job{
+					ID:        tag,
+					Dst:       job.dst,
+					PlanError: fmt.Errorf("verify %s: %w", job.src, err),
+				})
+				break
 			}
+			job.verification = toVerification(info)
 		}
 
 		// Snapshot referrers at plan time, not inside the retry closure —
@@ -141,9 +171,10 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 		}
 
 		plan.Jobs = append(plan.Jobs, sync.Job{
-			ID:  tag,
-			Dst: job.dst,
-			Run: func(jctx context.Context) (sync.Outcome, error) { return m.runTag(jctx, job) },
+			ID:           tag,
+			Dst:          job.dst,
+			Verification: job.verification,
+			Run:          func(jctx context.Context) (sync.JobResult, error) { return m.runTag(jctx, job) },
 		})
 	}
 	return plan, nil
@@ -151,7 +182,7 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 
 // runTag executes one tag's mirror flow. Idempotent — safe to retry under
 // the runner's per-tag budget.
-func (m *mirror) runTag(ctx context.Context, j tagJob) (sync.Outcome, error) {
+func (m *mirror) runTag(ctx context.Context, j tagJob) (sync.JobResult, error) {
 	start := time.Now()
 	m.opts.Logger.Info("mirroring tag", "src", j.src, "dst", j.dst)
 
@@ -159,24 +190,30 @@ func (m *mirror) runTag(ctx context.Context, j tagJob) (sync.Outcome, error) {
 	// skip the redundant src-side Digest call.
 	cmp, err := m.compareTag(ctx, j.src, j.dst, j.srcDigest)
 	if err != nil {
-		return "", err
+		return sync.JobResult{}, err
 	}
 
-	oc, err := m.applyOutcome(ctx, j.src, j.dst, cmp, j.overwrite, m.opts.CopyJobs)
+	st, reason, err := m.applyOutcome(ctx, j.src, j.dst, cmp, j.overwrite, m.opts.CopyJobs)
 	if err != nil {
-		return "", err
+		// Compare resolved the source digest before the copy failed — keep it
+		// on the failed row.
+		return sync.JobResult{Digest: cmp.SrcDigest}, err
 	}
 
+	var refResults []sync.ReferrerResult
 	if len(j.refs) > 0 {
-		if err := m.mirrorReferrers(ctx, j.refs, j.overwrite); err != nil {
-			return "", err
+		refResults, err = m.mirrorReferrers(ctx, j.refs, j.overwrite)
+		if err != nil {
+			// A referrer failure fails the parent tag; carry the digest and the
+			// partial referrer list (including the failed one) on the row.
+			return sync.JobResult{Digest: cmp.SrcDigest, Referrers: refResults}, err
 		}
 	}
 	m.opts.Logger.Info("tag done",
 		"src", j.src,
-		"outcome", string(oc),
+		"status", string(st),
 		"elapsed", time.Since(start).Round(time.Millisecond))
-	return oc, nil
+	return sync.JobResult{Status: st, Digest: cmp.SrcDigest, Reason: reason, Referrers: refResults}, nil
 }
 
 // compareTag does Compare or CompareWithKnownSrc depending on whether we
@@ -188,69 +225,107 @@ func (m *mirror) compareTag(ctx context.Context, src, dst, knownSrcDigest string
 	return m.client.Compare(ctx, src, dst)
 }
 
-// applyOutcome consolidates the Compare → Copy/skip switch shared between
-// the parent tag and each referrer.
-func (m *mirror) applyOutcome(ctx context.Context, src, dst string, cmp oci.CompareResult, overwrite bool, jobs int) (sync.Outcome, error) {
+// resolveCompare maps a Compare state to a status + skip reason, running copy
+// for the StateMissing/StateDrifted cases unless dry-run. copy performs the
+// actual mirror; onDrift logs the overwrite=false skip. Shared by the parent
+// tag and each referrer so the status mapping lives in one place.
+func (m *mirror) resolveCompare(cmp oci.CompareResult, overwrite bool, copyFn func() error, onDrift func()) (sync.Status, string, error) {
 	switch cmp.State {
 	case oci.StateEqual:
-		return sync.OutcomeSkipped, nil
+		return sync.StatusSkipped, sync.ReasonUpToDate, nil
 	case oci.StateMissing:
 		if m.opts.DryRun {
-			return sync.OutcomeWouldCopy, nil
+			return sync.StatusWouldCopy, "", nil
 		}
-		if err := m.client.CopyTag(ctx, src, dst, jobs); err != nil {
-			return "", err
+		if err := copyFn(); err != nil {
+			return "", "", err
 		}
-		return sync.OutcomeCopied, nil
+		return sync.StatusCopied, "", nil
 	case oci.StateDrifted:
 		if !overwrite {
+			onDrift()
+			return sync.StatusDrifted, "", nil
+		}
+		if m.opts.DryRun {
+			return sync.StatusWouldOverwrite, "", nil
+		}
+		if err := copyFn(); err != nil {
+			return "", "", err
+		}
+		return sync.StatusOverwritten, "", nil
+	}
+	return "", "", fmt.Errorf("compare returned unknown state %d", cmp.State)
+}
+
+// applyOutcome resolves the Compare → Copy/skip switch for the parent tag.
+func (m *mirror) applyOutcome(ctx context.Context, src, dst string, cmp oci.CompareResult, overwrite bool, jobs int) (sync.Status, string, error) {
+	return m.resolveCompare(cmp, overwrite,
+		func() error { return m.client.CopyTag(ctx, src, dst, jobs) },
+		func() {
 			m.opts.Logger.Warn("destination tag drifted from source; skipping (overwrite=false)",
 				"src", src, "src_digest", cmp.SrcDigest,
 				"dst", dst, "dst_digest", cmp.DstDigest)
-			return sync.OutcomeDrifted, nil
-		}
-		if m.opts.DryRun {
-			return sync.OutcomeWouldOverwrite, nil
-		}
-		if err := m.client.CopyTag(ctx, src, dst, jobs); err != nil {
-			return "", err
-		}
-		return sync.OutcomeOverwritten, nil
-	}
-	return "", fmt.Errorf("compare returned unknown state %d", cmp.State)
+		})
 }
 
 // mirrorReferrers walks the snapshotted referrer set and applies the same
-// Compare → Copy gate as the parent tag. The src digest of each referrer is
-// the referrer's own digest (we know it without a network call), so we use
-// CompareWithKnownSrc to skip the redundant src-side fetch per referrer.
-func (m *mirror) mirrorReferrers(ctx context.Context, refs []oci.Referrer, overwrite bool) error {
+// Compare → Copy gate as the parent tag, collecting a per-referrer result row.
+// The src digest of each referrer is the referrer's own digest (we know it
+// without a network call), so we use CompareWithKnownSrc to skip the redundant
+// src-side fetch per referrer. On the first referrer error it appends a failed
+// row for that referrer and returns the rows collected so far alongside the
+// error (a referrer failure fails the parent tag).
+func (m *mirror) mirrorReferrers(ctx context.Context, refs []oci.Referrer, overwrite bool) ([]sync.ReferrerResult, error) {
+	results := make([]sync.ReferrerResult, 0, len(refs))
 	for _, r := range refs {
 		dstRef := m.entry.Destination + "@" + r.Digest
 		cmp, err := m.client.CompareWithKnownSrc(ctx, r.Digest, dstRef)
 		if err != nil {
-			return fmt.Errorf("compare referrer %s: %w", r.Digest, err)
+			results = append(results, sync.ReferrerResult{
+				Digest: r.Digest, ArtifactType: r.ArtifactType, Status: sync.StatusFailed,
+			})
+			return results, fmt.Errorf("compare referrer %s: %w", r.Digest, err)
 		}
-		switch cmp.State {
-		case oci.StateEqual:
-			continue
-		case oci.StateMissing, oci.StateDrifted:
-			if cmp.State == oci.StateDrifted && !overwrite {
-				m.opts.Logger.Warn("destination referrer drifted; skipping (overwrite=false)",
-					"src_repo", m.entry.Source, "dst_repo", m.entry.Destination,
-					"digest", r.Digest, "dst_digest", cmp.DstDigest)
-				continue
-			}
-			if m.opts.DryRun {
-				m.opts.Logger.Info("would copy referrer (dry-run)",
-					"src_repo", m.entry.Source, "dst_repo", m.entry.Destination,
-					"digest", r.Digest, "state", cmp.State.String())
-				continue
-			}
-			if err := m.client.CopyReferrer(ctx, m.entry.Source, m.entry.Destination, r.Digest); err != nil {
-				return err
-			}
+		st, reason, err := m.applyReferrerOutcome(ctx, r, cmp, overwrite)
+		if err != nil {
+			results = append(results, sync.ReferrerResult{
+				Digest: r.Digest, ArtifactType: r.ArtifactType, Status: sync.StatusFailed,
+			})
+			return results, err
 		}
+		results = append(results, sync.ReferrerResult{
+			Digest: r.Digest, ArtifactType: r.ArtifactType, Status: st, Reason: reason,
+		})
 	}
-	return nil
+	return results, nil
+}
+
+// applyReferrerOutcome resolves one referrer's compare state, copying via
+// CopyReferrer. Mirrors applyOutcome through the shared resolveCompare switch.
+func (m *mirror) applyReferrerOutcome(ctx context.Context, r oci.Referrer, cmp oci.CompareResult, overwrite bool) (sync.Status, string, error) {
+	return m.resolveCompare(cmp, overwrite,
+		func() error { return m.client.CopyReferrer(ctx, m.entry.Source, m.entry.Destination, r.Digest) },
+		func() {
+			m.opts.Logger.Warn("destination referrer drifted; skipping (overwrite=false)",
+				"src_repo", m.entry.Source, "dst_repo", m.entry.Destination,
+				"digest", r.Digest, "dst_digest", cmp.DstDigest)
+		})
+}
+
+// toVerification converts the oci-layer verification info into the report's
+// wire type, formatting the integrated time as RFC 3339 (omitted when zero).
+// Returns nil when info is nil (no verify configured / nothing confirmed).
+func toVerification(info *oci.VerificationInfo) *sync.Verification {
+	if info == nil {
+		return nil
+	}
+	v := &sync.Verification{
+		Provider: info.Provider,
+		Issuer:   info.Issuer,
+		Identity: info.Identity,
+	}
+	if !info.IntegratedTime.IsZero() {
+		v.IntegratedTime = info.IntegratedTime.UTC().Format(time.RFC3339)
+	}
+	return v
 }

--- a/internal/artifacts/mirror_test.go
+++ b/internal/artifacts/mirror_test.go
@@ -55,13 +55,17 @@ func newRunner() *sync.Runner {
 }
 
 type recordingVerifier struct {
-	refs []string
-	info *oci.VerificationInfo
-	err  error
+	refs        []string
+	info        *oci.VerificationInfo
+	err         error
+	afterVerify func()
 }
 
 func (v *recordingVerifier) Verify(_ context.Context, ref string, _ config.ArtifactVerification) (*oci.VerificationInfo, error) {
 	v.refs = append(v.refs, ref)
+	if v.afterVerify != nil {
+		v.afterVerify()
+	}
 	return v.info, v.err
 }
 
@@ -111,7 +115,7 @@ func TestMirror_VerifiesSelectedTags(t *testing.T) {
 	dst := repo("verify-dst")
 
 	testregistry.PushImage(t, src+":1.0.0")
-	testregistry.PushImage(t, src+":1.1.0")
+	srcDigest := testregistry.PushImage(t, src+":1.1.0")
 
 	c := oci.NewClient(oci.Insecure())
 	entry := config.ArtifactEntry{
@@ -131,6 +135,7 @@ func TestMirror_VerifiesSelectedTags(t *testing.T) {
 		Provider:       config.VerifyProviderCosign,
 		Issuer:         "https://token.actions.githubusercontent.com",
 		Identity:       "https://github.com/example/app/.github/workflows/release.yml@refs/tags/1.1.0",
+		Digest:         srcDigest,
 		IntegratedTime: integrated,
 	}}
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
@@ -157,6 +162,57 @@ func TestMirror_VerifiesSelectedTags(t *testing.T) {
 	// Age/minAge only appear on the too-new skip, not a normal verified copy.
 	g.Expect(row.Verification.Age).To(BeEmpty())
 	g.Expect(row.Verification.MinAge).To(BeEmpty())
+}
+
+func TestMirror_CopiesVerifiedDigestWhenTagMoves(t *testing.T) {
+	g := NewWithT(t)
+	src := repo("verify-move-src")
+	dst := repo("verify-move-dst")
+
+	verifiedDigest := testregistry.PushImage(t, src+":1.0.0")
+	var movedDigest string
+
+	c := oci.NewClient(oci.Insecure())
+	entry := config.ArtifactEntry{
+		Source:      src,
+		Destination: dst,
+		Selector:    config.Selector{Limit: new(1)},
+		Verify: &config.ArtifactVerification{
+			Provider: config.VerifyProviderCosign,
+			MatchOIDCIdentity: []config.OIDCIdentity{{
+				Issuer:  "https://token.actions.githubusercontent.com",
+				Subject: `^https://github\.com/example/.*$`,
+			}},
+		},
+	}
+	verifier := &recordingVerifier{
+		info: &oci.VerificationInfo{
+			Provider: config.VerifyProviderCosign,
+			Digest:   verifiedDigest,
+		},
+		afterVerify: func() {
+			movedDigest = testregistry.PushImage(t, src+":1.0.0")
+		},
+	}
+
+	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
+		New(c, entry, Options{
+			Verifier: verifier,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(movedDigest).ToNot(BeEmpty())
+	g.Expect(movedDigest).ToNot(Equal(verifiedDigest))
+	g.Expect(verifier.refs).To(Equal([]string{src + ":1.0.0"}))
+
+	copied := tagsWithStatus(res.Entries[0], sync.StatusCopied)
+	g.Expect(copied).To(HaveLen(1))
+	g.Expect(copied[0].Digest).To(Equal(verifiedDigest))
+
+	dstDigest, err := crane.Digest(dst+":1.0.0", crane.Insecure)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dstDigest).To(Equal(verifiedDigest))
 }
 
 func TestMirror_VerificationFailureStopsPlanning(t *testing.T) {

--- a/internal/artifacts/mirror_test.go
+++ b/internal/artifacts/mirror_test.go
@@ -56,12 +56,25 @@ func newRunner() *sync.Runner {
 
 type recordingVerifier struct {
 	refs []string
+	info *oci.VerificationInfo
 	err  error
 }
 
-func (v *recordingVerifier) Verify(_ context.Context, ref string, _ config.ArtifactVerification) error {
+func (v *recordingVerifier) Verify(_ context.Context, ref string, _ config.ArtifactVerification) (*oci.VerificationInfo, error) {
 	v.refs = append(v.refs, ref)
-	return v.err
+	return v.info, v.err
+}
+
+// tagsWithStatus returns the entry's tag rows that landed in the given status,
+// for order-independent assertions against the row-based report.
+func tagsWithStatus(e sync.EntryResult, st sync.Status) []sync.TagResult {
+	var out []sync.TagResult
+	for _, t := range e.Tags {
+		if t.Status == st {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 func TestMirror_CopiesSelectedTags(t *testing.T) {
@@ -83,7 +96,7 @@ func TestMirror_CopiesSelectedTags(t *testing.T) {
 		New(c, entry, Options{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(HaveLen(2))
+	g.Expect(tagsWithStatus(res.Entries[0], sync.StatusCopied)).To(HaveLen(2))
 	g.Expect(res.HasFailures()).To(BeFalse())
 
 	tags, err := c.ListTags(context.Background(), dst)
@@ -113,14 +126,37 @@ func TestMirror_VerifiesSelectedTags(t *testing.T) {
 			}},
 		},
 	}
-	verifier := &recordingVerifier{}
-	plan, err := New(c, entry, Options{
-		Verifier: verifier,
-		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}).Plan(context.Background())
+	integrated := time.Date(2026, 5, 20, 9, 14, 2, 0, time.UTC)
+	verifier := &recordingVerifier{info: &oci.VerificationInfo{
+		Provider:       config.VerifyProviderCosign,
+		Issuer:         "https://token.actions.githubusercontent.com",
+		Identity:       "https://github.com/example/app/.github/workflows/release.yml@refs/tags/1.1.0",
+		IntegratedTime: integrated,
+	}}
+	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
+		New(c, entry, Options{
+			Verifier: verifier,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}),
+	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(plan.Jobs).To(HaveLen(1))
 	g.Expect(verifier.refs).To(Equal([]string{src + ":1.1.0"}))
+
+	copied := tagsWithStatus(res.Entries[0], sync.StatusCopied)
+	g.Expect(copied).To(HaveLen(1))
+	row := copied[0]
+	g.Expect(row.Tag).To(Equal("1.1.0"))
+	// The source digest the compare resolved is recorded on the row.
+	g.Expect(row.Digest).To(HavePrefix("sha256:"))
+	// The confirmed signature metadata is attached.
+	g.Expect(row.Verification).ToNot(BeNil())
+	g.Expect(row.Verification.Provider).To(Equal("cosign"))
+	g.Expect(row.Verification.Issuer).To(Equal("https://token.actions.githubusercontent.com"))
+	g.Expect(row.Verification.Identity).To(ContainSubstring("github.com/example/app"))
+	g.Expect(row.Verification.IntegratedTime).To(Equal("2026-05-20T09:14:02Z"))
+	// Age/minAge only appear on the too-new skip, not a normal verified copy.
+	g.Expect(row.Verification.Age).To(BeEmpty())
+	g.Expect(row.Verification.MinAge).To(BeEmpty())
 }
 
 func TestMirror_VerificationFailureStopsPlanning(t *testing.T) {
@@ -128,13 +164,16 @@ func TestMirror_VerificationFailureStopsPlanning(t *testing.T) {
 	src := repo("verify-fail-src")
 	dst := repo("verify-fail-dst")
 
+	// Two tags; the selector orders highest-semver first, so 1.1.0 is verified
+	// first. A verify failure there must stop planning before 1.0.0.
 	testregistry.PushImage(t, src+":1.0.0")
+	testregistry.PushImage(t, src+":1.1.0")
 
 	c := oci.NewClient(oci.Insecure())
 	entry := config.ArtifactEntry{
 		Source:      src,
 		Destination: dst,
-		Selector:    config.Selector{Limit: new(1)},
+		Selector:    config.Selector{Limit: new(2)},
 		Verify: &config.ArtifactVerification{
 			Provider: config.VerifyProviderCosign,
 			MatchOIDCIdentity: []config.OIDCIdentity{{
@@ -144,14 +183,38 @@ func TestMirror_VerificationFailureStopsPlanning(t *testing.T) {
 		},
 	}
 	verifier := &recordingVerifier{err: errors.New("denied")}
+
+	// Plan no longer errors on a verify failure: it appends a single failed job
+	// and stops (the entry stays runnable).
 	plan, err := New(c, entry, Options{
 		Verifier: verifier,
 		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}).Plan(context.Background())
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("verify " + src + ":1.0.0"))
-	g.Expect(err.Error()).To(ContainSubstring("denied"))
-	g.Expect(plan.Jobs).To(BeEmpty())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(plan.Jobs).To(HaveLen(1)) // stopped after the first verify failure
+	g.Expect(verifier.refs).To(Equal([]string{src + ":1.1.0"}))
+
+	verifier = &recordingVerifier{err: errors.New("denied")}
+	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
+		New(c, entry, Options{
+			Verifier: verifier,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	// The entry itself completed; the failure is a per-tag failed row.
+	g.Expect(res.Entries[0].Status).To(Equal(sync.EntryCompleted))
+	g.Expect(res.Entries[0].Tags).To(HaveLen(1))
+	failed := res.Entries[0].Tags[0]
+	g.Expect(failed.Tag).To(Equal("1.1.0"))
+	g.Expect(failed.Status).To(Equal(sync.StatusFailed))
+	g.Expect(failed.Error).To(ContainSubstring("verify " + src + ":1.1.0"))
+	g.Expect(failed.Error).To(ContainSubstring("denied"))
+	// A verify-failed row carries no digest and no verification block.
+	g.Expect(failed.Digest).To(BeEmpty())
+	g.Expect(failed.Verification).To(BeNil())
+	g.Expect(res.HasFailures()).To(BeTrue())
+	g.Expect(res.ExitCode()).To(Equal(1))
 }
 
 func TestMirror_SkipsSignatureTooNew(t *testing.T) {
@@ -176,11 +239,21 @@ func TestMirror_SkipsSignatureTooNew(t *testing.T) {
 		},
 		IncludeReferrers: true,
 	}
-	verifier := &recordingVerifier{err: &oci.SignatureTooNewError{
-		IntegratedTime: time.Now().Add(-30 * time.Minute),
-		Age:            30 * time.Minute,
-		MinAge:         time.Hour,
-	}}
+	integrated := time.Now().Add(-30 * time.Minute)
+	verifier := &recordingVerifier{
+		info: &oci.VerificationInfo{
+			Provider:       config.VerifyProviderCosign,
+			Issuer:         "https://token.actions.githubusercontent.com",
+			Identity:       "https://github.com/example/app/.github/workflows/release.yml@refs/tags/1.0.0",
+			Digest:         "sha256:9a8b7c6d5e4f30211223344556677889aabbccddeeff00112233445566778899",
+			IntegratedTime: integrated,
+		},
+		err: &oci.SignatureTooNewError{
+			IntegratedTime: integrated,
+			Age:            30 * time.Minute,
+			MinAge:         time.Hour,
+		},
+	}
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{
 		New(c, entry, Options{
 			Verifier: verifier,
@@ -189,8 +262,21 @@ func TestMirror_SkipsSignatureTooNew(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.HasFailures()).To(BeFalse())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeSkipped]).To(Equal([]string{"1.0.0"}))
 	g.Expect(verifier.refs).To(Equal([]string{src + ":1.0.0"}))
+
+	skipped := tagsWithStatus(res.Entries[0], sync.StatusSkipped)
+	g.Expect(skipped).To(HaveLen(1))
+	row := skipped[0]
+	g.Expect(row.Tag).To(Equal("1.0.0"))
+	// A skip always carries a reason; here it is the deferral.
+	g.Expect(row.Reason).To(Equal(sync.ReasonSignatureTooNew))
+	// The digest is known even though nothing was copied.
+	g.Expect(row.Digest).To(Equal("sha256:9a8b7c6d5e4f30211223344556677889aabbccddeeff00112233445566778899"))
+	// The too-new skip carries the age/minAge in its verification block.
+	g.Expect(row.Verification).ToNot(BeNil())
+	g.Expect(row.Verification.Age).To(Equal("30m0s"))
+	g.Expect(row.Verification.MinAge).To(Equal("1h0m0s"))
+	g.Expect(row.Verification.Issuer).To(Equal("https://token.actions.githubusercontent.com"))
 
 	_, err = crane.Digest(dst+":1.0.0", crane.Insecure)
 	g.Expect(err).To(HaveOccurred())
@@ -214,8 +300,11 @@ func TestMirror_SkipsEqual(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	res2, err := runner.Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res2.Entries[0].Outcomes[sync.OutcomeSkipped]).To(HaveLen(1))
-	g.Expect(res2.Entries[0].Outcomes[sync.OutcomeCopied]).To(BeEmpty())
+	skipped := tagsWithStatus(res2.Entries[0], sync.StatusSkipped)
+	g.Expect(skipped).To(HaveLen(1))
+	// An up-to-date skip always carries its reason.
+	g.Expect(skipped[0].Reason).To(Equal(sync.ReasonUpToDate))
+	g.Expect(tagsWithStatus(res2.Entries[0], sync.StatusCopied)).To(BeEmpty())
 }
 
 func TestMirror_DriftWithoutOverwrite(t *testing.T) {
@@ -234,7 +323,9 @@ func TestMirror_DriftWithoutOverwrite(t *testing.T) {
 		New(c, entry, Options{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeDrifted]).To(Equal([]string{"1.0.0"}))
+	drifted := tagsWithStatus(res.Entries[0], sync.StatusDrifted)
+	g.Expect(drifted).To(HaveLen(1))
+	g.Expect(drifted[0].Tag).To(Equal("1.0.0"))
 	g.Expect(res.HasDrift()).To(BeTrue())
 	g.Expect(res.HasFailures()).To(BeFalse())
 	g.Expect(res.ExitCode()).To(Equal(2))
@@ -256,7 +347,7 @@ func TestMirror_DriftWithOverwrite(t *testing.T) {
 		New(c, entry, Options{Overwrite: true, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeOverwritten]).To(HaveLen(1))
+	g.Expect(tagsWithStatus(res.Entries[0], sync.StatusOverwritten)).To(HaveLen(1))
 
 	dig, err := crane.Digest(dst+":1.0.0", crane.Insecure)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -293,7 +384,23 @@ func TestMirror_IncludeReferrers(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.HasFailures()).To(BeFalse())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(HaveLen(1))
+	copied := tagsWithStatus(res.Entries[0], sync.StatusCopied)
+	g.Expect(copied).To(HaveLen(1))
+
+	// The copied tag row carries a referrers[] array, one entry per referrer.
+	refs := copied[0].Referrers
+	g.Expect(refs).To(HaveLen(2))
+	refTypes := make([]string, 0, len(refs))
+	for _, r := range refs {
+		g.Expect(r.Digest).To(HavePrefix("sha256:"))
+		g.Expect(r.Status).To(Equal(sync.StatusCopied))
+		g.Expect(r.Reason).To(BeEmpty()) // reason only on skipped
+		refTypes = append(refTypes, r.ArtifactType)
+	}
+	g.Expect(refTypes).To(ConsistOf(
+		"application/vnd.dev.cosign.artifact.sig.v1+json",
+		"application/spdx+json",
+	))
 
 	dstRepo, err := name.NewRepository(dst, name.Insecure)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -317,8 +424,18 @@ func TestMirror_IncludeReferrers(t *testing.T) {
 		New(c, entry, Options{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res2.Entries[0].Outcomes[sync.OutcomeSkipped]).To(HaveLen(1))
-	g.Expect(res2.Entries[0].Outcomes[sync.OutcomeCopied]).To(BeEmpty())
+	skipped := tagsWithStatus(res2.Entries[0], sync.StatusSkipped)
+	g.Expect(skipped).To(HaveLen(1))
+	g.Expect(tagsWithStatus(res2.Entries[0], sync.StatusCopied)).To(BeEmpty())
+
+	// Re-run: the subject and both referrers are up-to-date, each carrying a
+	// skipped status with the up-to-date reason.
+	g.Expect(skipped[0].Reason).To(Equal(sync.ReasonUpToDate))
+	g.Expect(skipped[0].Referrers).To(HaveLen(2))
+	for _, r := range skipped[0].Referrers {
+		g.Expect(r.Status).To(Equal(sync.StatusSkipped))
+		g.Expect(r.Reason).To(Equal(sync.ReasonUpToDate))
+	}
 }
 
 func TestMirror_DryRun(t *testing.T) {
@@ -336,8 +453,8 @@ func TestMirror_DryRun(t *testing.T) {
 		New(c, entry, Options{DryRun: true, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeWouldCopy]).To(HaveLen(1))
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(BeEmpty())
+	g.Expect(tagsWithStatus(res.Entries[0], sync.StatusWouldCopy)).To(HaveLen(1))
+	g.Expect(tagsWithStatus(res.Entries[0], sync.StatusCopied)).To(BeEmpty())
 
 	_, err = c.ListTags(context.Background(), dst)
 	g.Expect(err).To(HaveOccurred()) // 404 — repo was never created

--- a/internal/charts/mirror.go
+++ b/internal/charts/mirror.go
@@ -75,10 +75,11 @@ type versionJob struct {
 }
 
 // Plan resolves matching chart versions and emits one Job per version.
-// Plan.Name uses "<source>/<chartName>" so logs and summary lines disambiguate
-// when multiple charts share a source URL.
+// Plan.Source uses "<source>/<chartName>" so logs and report rows disambiguate
+// when multiple charts share a source URL; Plan.Destination is the OCI repo the
+// chart lands in (destination base + chart name).
 func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
-	plan := sync.Plan{Name: m.planName()}
+	plan := sync.Plan{Source: m.planName(), Destination: m.dstRepo()}
 
 	versions, err := m.source.ListVersions(ctx, m.entry.Name)
 	if err != nil {

--- a/internal/charts/mirror.go
+++ b/internal/charts/mirror.go
@@ -112,7 +112,7 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 		plan.Jobs = append(plan.Jobs, sync.Job{
 			ID:  version,
 			Dst: job.dst,
-			Run: func(jctx context.Context) (sync.Outcome, error) { return m.runVersion(jctx, job) },
+			Run: func(jctx context.Context) (sync.JobResult, error) { return m.runVersion(jctx, job) },
 		})
 	}
 	return plan, nil
@@ -120,30 +120,30 @@ func (m *mirror) Plan(ctx context.Context) (sync.Plan, error) {
 
 // runVersion mirrors one chart version. Idempotent — safe to retry under
 // the runner's per-tag budget.
-func (m *mirror) runVersion(ctx context.Context, j versionJob) (sync.Outcome, error) {
+func (m *mirror) runVersion(ctx context.Context, j versionJob) (sync.JobResult, error) {
 	start := time.Now()
 	chartRef := m.entry.Name + "@" + j.version
 	m.opts.Logger.Info("mirroring chart", "chart", chartRef, "dst", j.dst)
 
-	oc, err := m.mirrorVersion(ctx, j)
+	res, err := m.mirrorVersion(ctx, j)
 	if err != nil {
-		return "", err
+		return res, err
 	}
 	m.opts.Logger.Info("chart done",
 		"chart", chartRef,
 		"dst", j.dst,
-		"outcome", string(oc),
+		"status", string(res.Status),
 		"elapsed", time.Since(start).Round(time.Millisecond))
-	return oc, nil
+	return res, nil
 }
 
-func (m *mirror) mirrorVersion(ctx context.Context, j versionJob) (sync.Outcome, error) {
+func (m *mirror) mirrorVersion(ctx context.Context, j versionJob) (sync.JobResult, error) {
 	// Download src .tgz once. Bytes are pushed verbatim as the chart layer,
 	// so sha256(tgz) is also the chart-layer digest at the destination if
 	// our push goes through.
 	tgz, err := m.source.Download(ctx, m.entry.Name, j.version)
 	if err != nil {
-		return "", err
+		return sync.JobResult{}, err
 	}
 	srcLayerDigest := digestSHA256(tgz)
 
@@ -153,34 +153,34 @@ func (m *mirror) mirrorVersion(ctx context.Context, j versionJob) (sync.Outcome,
 	// layer digests are content-addressed and stable.
 	dstLayerDigest, err := m.client.HelmChartLayerDigest(ctx, j.dst)
 	if err != nil {
-		return "", err
+		return sync.JobResult{Digest: srcLayerDigest}, err
 	}
 
 	switch dstLayerDigest {
 	case "":
 		if m.opts.DryRun {
-			return sync.OutcomeWouldCopy, nil
+			return sync.JobResult{Status: sync.StatusWouldCopy, Digest: srcLayerDigest}, nil
 		}
 		if err := m.push(ctx, j.dst, tgz); err != nil {
-			return "", err
+			return sync.JobResult{Digest: srcLayerDigest}, err
 		}
-		return sync.OutcomeCopied, nil
+		return sync.JobResult{Status: sync.StatusCopied, Digest: srcLayerDigest}, nil
 	case srcLayerDigest:
-		return sync.OutcomeSkipped, nil
+		return sync.JobResult{Status: sync.StatusSkipped, Digest: srcLayerDigest, Reason: sync.ReasonUpToDate}, nil
 	default:
 		if !j.overwrite {
 			m.opts.Logger.Warn("destination chart drifted from source; skipping (overwrite=false)",
 				"chart", m.entry.Name, "version", j.version,
 				"src_digest", srcLayerDigest, "dst_digest", dstLayerDigest)
-			return sync.OutcomeDrifted, nil
+			return sync.JobResult{Status: sync.StatusDrifted, Digest: srcLayerDigest}, nil
 		}
 		if m.opts.DryRun {
-			return sync.OutcomeWouldOverwrite, nil
+			return sync.JobResult{Status: sync.StatusWouldOverwrite, Digest: srcLayerDigest}, nil
 		}
 		if err := m.push(ctx, j.dst, tgz); err != nil {
-			return "", err
+			return sync.JobResult{Digest: srcLayerDigest}, err
 		}
-		return sync.OutcomeOverwritten, nil
+		return sync.JobResult{Status: sync.StatusOverwritten, Digest: srcLayerDigest}, nil
 	}
 }
 

--- a/internal/charts/mirror_test.go
+++ b/internal/charts/mirror_test.go
@@ -50,6 +50,28 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// versionsWithStatus returns the chart versions (tag IDs) of the entry's rows
+// that landed in the given status.
+func versionsWithStatus(e sync.EntryResult, st sync.Status) []string {
+	var out []string
+	for _, t := range e.Tags {
+		if t.Status == st {
+			out = append(out, t.Tag)
+		}
+	}
+	return out
+}
+
+// rowByTag returns the entry's row for the given version.
+func rowByTag(e sync.EntryResult, tag string) (sync.TagResult, bool) {
+	for _, t := range e.Tags {
+		if t.Tag == tag {
+			return t, true
+		}
+	}
+	return sync.TagResult{}, false
+}
+
 func newHTTPHelmRepo(t *testing.T, versions ...string) string {
 	t.Helper()
 	testregistry.UseEmptyDockerConfig(t)
@@ -102,7 +124,11 @@ func TestChartsMirror_CopiesTopN(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.HasFailures()).To(BeFalse())
 	// Top-2 of {0.1.0, 0.2.0, 1.0.0, 1.1.0} by semver = 1.0.0 and 1.1.0.
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(ConsistOf("1.0.0", "1.1.0"))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusCopied)).To(ConsistOf("1.0.0", "1.1.0"))
+	// The chart-layer digest is recorded on every row.
+	row, ok := rowByTag(res.Entries[0], "1.1.0")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(row.Digest).To(HavePrefix("sha256:"))
 
 	tags, err := c.ListTags(context.Background(), dst+"/podinfo")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -127,7 +153,7 @@ func TestChartsMirror_VersionConstraint(t *testing.T) {
 
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(ConsistOf("1.0.0", "1.1.0"))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusCopied)).To(ConsistOf("1.0.0", "1.1.0"))
 }
 
 func TestChartsMirror_SkipsExisting(t *testing.T) {
@@ -152,8 +178,12 @@ func TestChartsMirror_SkipsExisting(t *testing.T) {
 	// Re-run: same source bytes → same chart-layer digest → skipped.
 	res, err := runner.Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeSkipped]).To(Equal([]string{"1.0.0"}))
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(BeEmpty())
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusSkipped)).To(Equal([]string{"1.0.0"}))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusCopied)).To(BeEmpty())
+	// An up-to-date skip always carries its reason.
+	row, ok := rowByTag(res.Entries[0], "1.0.0")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(row.Reason).To(Equal(sync.ReasonUpToDate))
 }
 
 func TestChartsMirror_DriftWithoutOverwrite(t *testing.T) {
@@ -177,7 +207,7 @@ func TestChartsMirror_DriftWithoutOverwrite(t *testing.T) {
 
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeDrifted]).To(Equal([]string{"1.0.0"}))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusDrifted)).To(Equal([]string{"1.0.0"}))
 	g.Expect(res.HasDrift()).To(BeTrue())
 	g.Expect(res.HasFailures()).To(BeFalse())
 	g.Expect(res.ExitCode()).To(Equal(2))
@@ -202,12 +232,12 @@ func TestChartsMirror_DriftWithOverwrite(t *testing.T) {
 
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeOverwritten]).To(Equal([]string{"1.0.0"}))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusOverwritten)).To(Equal([]string{"1.0.0"}))
 
 	// Re-run with overwrite still on: dst now matches src → skipped.
 	res2, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res2.Entries[0].Outcomes[sync.OutcomeSkipped]).To(Equal([]string{"1.0.0"}))
+	g.Expect(versionsWithStatus(res2.Entries[0], sync.StatusSkipped)).To(Equal([]string{"1.0.0"}))
 }
 
 func TestChartsMirror_DryRun(t *testing.T) {
@@ -227,7 +257,7 @@ func TestChartsMirror_DryRun(t *testing.T) {
 
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeWouldCopy]).To(ConsistOf("1.0.0", "2.0.0"))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusWouldCopy)).To(ConsistOf("1.0.0", "2.0.0"))
 	g.Expect(res.HasFailures()).To(BeFalse())
 
 	// Destination must remain empty.
@@ -255,7 +285,7 @@ func TestChartsMirror_OCISourceToOCIDest(t *testing.T) {
 
 	res, err := newRunner().Run(context.Background(), []sync.EntryMirror{mirror})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[sync.OutcomeCopied]).To(ConsistOf("1.0.0", "1.1.0"))
+	g.Expect(versionsWithStatus(res.Entries[0], sync.StatusCopied)).To(ConsistOf("1.0.0", "1.1.0"))
 
 	tags, err := c.ListTags(context.Background(), dstBase+"/podinfo")
 	g.Expect(err).ToNot(HaveOccurred())

--- a/internal/oci/verify.go
+++ b/internal/oci/verify.go
@@ -6,6 +6,7 @@ package oci
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -27,6 +28,19 @@ const (
 	minBundleVersion              = "v0.3"
 	sigstoreBundleMediaTypePrefix = "application/vnd.dev.sigstore.bundle"
 )
+
+// VerificationInfo carries the metadata of a confirmed cosign signature, so
+// the report can record who signed it and when. Only Provider is guaranteed;
+// the rest is best-effort: Issuer/Identity are populated from the keyless
+// certificate identity, and IntegratedTime only when the bundle carries a
+// verified transparency-log timestamp (otherwise it is the zero time).
+type VerificationInfo struct {
+	Provider       string
+	Issuer         string
+	Identity       string
+	Digest         string
+	IntegratedTime time.Time
+}
 
 // SignatureTooNewError reports a valid signature that has not aged past the
 // configured minimum transparency-log integration age.
@@ -59,54 +73,59 @@ func NewVerifier(client *Client) *Verifier {
 	return &Verifier{client: client}
 }
 
-// Verify checks the cosign signature for ref against the configured OIDC identities.
-func (v *Verifier) Verify(ctx context.Context, ref string, cfg config.ArtifactVerification) error {
+// Verify checks the cosign signature for ref against the configured OIDC
+// identities. On success it returns the confirmed VerificationInfo (provider,
+// keyless identity/issuer, source digest, and the Tlog integrated time when
+// present). When the signature is valid but younger than cfg.MinAge it returns
+// both the info and a *SignatureTooNewError so the caller can record the
+// deferral with its metadata; any other failure returns (nil, err).
+func (v *Verifier) Verify(ctx context.Context, ref string, cfg config.ArtifactVerification) (*VerificationInfo, error) {
 	if strings.TrimSpace(cfg.Provider) != config.VerifyProviderCosign {
-		return fmt.Errorf("unsupported verification provider %q", cfg.Provider)
+		return nil, fmt.Errorf("unsupported verification provider %q", cfg.Provider)
 	}
 	if len(cfg.MatchOIDCIdentity) == 0 {
-		return fmt.Errorf("at least one OIDC identity matcher is required")
+		return nil, fmt.Errorf("at least one OIDC identity matcher is required")
 	}
 
 	ref = strings.TrimPrefix(ref, "oci://")
 	parsed, err := name.ParseReference(ref, v.client.staticNameOpts...)
 	if err != nil {
-		return fmt.Errorf("parse reference %q: %w", ref, err)
+		return nil, fmt.Errorf("parse reference %q: %w", ref, err)
 	}
 
 	opts := v.remoteOptions(ctx)
 	desc, err := remote.Get(parsed, opts...)
 	if err != nil {
-		return fmt.Errorf("fetch descriptor for %q: %w", ref, err)
+		return nil, fmt.Errorf("fetch descriptor for %q: %w", ref, err)
 	}
 
 	repo := parsed.Context()
 	digestRef := repo.Digest(desc.Digest.String())
 	idx, err := remote.Referrers(digestRef, opts...)
 	if err != nil {
-		return fmt.Errorf("list referrers for %s: %w", digestRef, err)
+		return nil, fmt.Errorf("list referrers for %s: %w", digestRef, err)
 	}
 	manifest, err := idx.IndexManifest()
 	if err != nil {
-		return fmt.Errorf("read referrers index for %s: %w", digestRef, err)
+		return nil, fmt.Errorf("read referrers index for %s: %w", digestRef, err)
 	}
 
 	bundleBytes, err := findSigstoreBundle(repo, manifest, opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var b bundle.Bundle
 	if err := b.UnmarshalJSON(bundleBytes); err != nil {
-		return fmt.Errorf("parse sigstore bundle: %w", err)
+		return nil, fmt.Errorf("parse sigstore bundle: %w", err)
 	}
 	if !b.MinVersion(minBundleVersion) {
-		return fmt.Errorf("unsupported sigstore bundle version: minimum %s required", minBundleVersion)
+		return nil, fmt.Errorf("unsupported sigstore bundle version: minimum %s required", minBundleVersion)
 	}
 
 	trustedRoot, err := v.getTrustedRoot()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sigVerifier, err := verify.NewVerifier(trustedRoot,
 		verify.WithSignedCertificateTimestamps(1),
@@ -114,16 +133,16 @@ func (v *Verifier) Verify(ctx context.Context, ref string, cfg config.ArtifactVe
 		verify.WithTransparencyLog(1),
 	)
 	if err != nil {
-		return fmt.Errorf("create signature verifier: %w", err)
+		return nil, fmt.Errorf("create signature verifier: %w", err)
 	}
 
 	identityOptions, err := certificateIdentityOptions(cfg.MatchOIDCIdentity)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	digestBytes, err := hex.DecodeString(desc.Digest.Hex)
 	if err != nil {
-		return fmt.Errorf("decode digest %s: %w", desc.Digest.String(), err)
+		return nil, fmt.Errorf("decode digest %s: %w", desc.Digest.String(), err)
 	}
 
 	policyOptions := append([]verify.PolicyOption(nil), identityOptions...)
@@ -133,17 +152,47 @@ func (v *Verifier) Verify(ctx context.Context, ref string, cfg config.ArtifactVe
 	)
 	result, err := sigVerifier.Verify(&b, policy)
 	if err != nil {
-		return fmt.Errorf("signature verification failed: %w", err)
+		return nil, fmt.Errorf("signature verification failed: %w", err)
 	}
+
+	info := &VerificationInfo{
+		Provider: config.VerifyProviderCosign,
+		Digest:   desc.Digest.String(),
+	}
+	// Read the actual signed identity off the verified certificate summary, not
+	// result.VerifiedIdentity — the latter echoes the configured matcher (whose
+	// SAN is empty when a regex matcher is used and whose issuer is only the
+	// configured value), whereas the certificate summary carries the real SAN
+	// and the OIDC issuer extension recorded at signing time.
+	if result.Signature != nil && result.Signature.Certificate != nil {
+		cert := result.Signature.Certificate
+		info.Identity = cert.SubjectAlternativeName
+		info.Issuer = cert.Extensions.Issuer
+	}
+	// IntegratedTime is best-effort: present only when the bundle carries a
+	// verified Tlog timestamp. Left zero (omitted in the report) otherwise.
+	if t, ok := signatureIntegratedTime(result); ok {
+		info.IntegratedTime = t
+	}
+
+	// On a too-new signature, hand back both the metadata and the typed signal
+	// so the caller can record the deferral with its verification block; any
+	// other minAge error (no Tlog timestamp) is a hard failure.
 	if cfg.MinAge != nil && cfg.MinAge.Duration > 0 {
 		if err := enforceMinAge(result, cfg.MinAge.Duration, time.Now()); err != nil {
-			return err
+			var tooNew *SignatureTooNewError
+			if errors.As(err, &tooNew) {
+				return info, err
+			}
+			return nil, err
 		}
 	}
-	return nil
+	return info, nil
 }
 
-func enforceMinAge(result *verify.VerificationResult, minAge time.Duration, now time.Time) error {
+// signatureIntegratedTime returns the oldest verified transparency-log (Tlog)
+// integration timestamp in the result, and whether one was found.
+func signatureIntegratedTime(result *verify.VerificationResult) (time.Time, bool) {
 	var signatureTime time.Time
 	for _, ts := range result.VerifiedTimestamps {
 		if ts.Type != "Tlog" || ts.Timestamp.IsZero() {
@@ -153,7 +202,16 @@ func enforceMinAge(result *verify.VerificationResult, minAge time.Duration, now 
 			signatureTime = ts.Timestamp
 		}
 	}
-	if signatureTime.IsZero() {
+	return signatureTime, !signatureTime.IsZero()
+}
+
+// enforceMinAge checks the signature's transparency-log age against minAge. It
+// returns a *SignatureTooNewError when the signature is valid but too young, a
+// plain error when no Tlog timestamp is available, and nil when old enough.
+// now is injectable so the age math is unit-testable.
+func enforceMinAge(result *verify.VerificationResult, minAge time.Duration, now time.Time) error {
+	signatureTime, ok := signatureIntegratedTime(result)
+	if !ok {
 		return fmt.Errorf("cannot enforce minAge: no verified transparency log integrated timestamps found in signature bundle")
 	}
 	signatureAge := now.Sub(signatureTime)

--- a/internal/sync/entry.go
+++ b/internal/sync/entry.go
@@ -37,38 +37,80 @@ type Job struct {
 	// this unit of work. Surfaced verbatim to OnJobFinished so the cmd
 	// layer can display the "-> dst" line without re-deriving it.
 	Dst string
+	// Verification carries the signature verification metadata confirmed at
+	// plan time (cosign keyless identity, issuer, integrated time). Nil when
+	// the entry has no verify: block. Attached to the tag row at record time
+	// so a verified copy is distinguishable from an unverified one.
+	Verification *Verification
+	// PlanError, when non-nil, marks a work unit the plan already determined
+	// has failed (e.g. signature verification failed at plan time). The runner
+	// records it as a StatusFailed row carrying this error and invokes neither
+	// Run nor any retry budget — Run is ignored when PlanError is set.
+	PlanError error
 	// Run performs the work. Must be safe to invoke multiple times — the
 	// runner may retry on transient errors. crane.Copy is content-addressed
 	// and idempotent at the blob level, so retrying a partially-copied tag
 	// does not corrupt anything.
-	Run func(ctx context.Context) (Outcome, error)
+	Run func(ctx context.Context) (JobResult, error)
 }
 
-// Outcome is the result of one Job.Run.
-type Outcome string
+// JobResult is the successful result of one Job.Run. It carries the per-tag
+// metadata the report records as a row: the status, the resolved source
+// digest, the skip reason (when skipped), and any mirrored referrers.
+type JobResult struct {
+	// Status is the outcome of the job (copied, skipped, drifted, …). Must be
+	// one of the Run-returnable values (Valid reports this); StatusFailed is
+	// runner-assigned on error and never returned here.
+	Status Status
+	// Digest is the source artifact digest, when the job resolved it. Present
+	// for every status whose path computed it (including the too-new skip).
+	Digest string
+	// Reason explains a skip (up-to-date or signature-too-new). Set only when
+	// Status is StatusSkipped; empty otherwise.
+	Reason string
+	// Referrers lists the mirrored sub-artifacts (signatures, SBOMs,
+	// attestations), in snapshot order. Empty unless includeReferrers is set.
+	Referrers []ReferrerResult
+}
+
+// Status is the result of one Job.Run, or runner-assigned on failure.
+type Status string
 
 const (
-	OutcomeCopied         Outcome = "copied"
-	OutcomeOverwritten    Outcome = "overwritten"
-	OutcomeSkipped        Outcome = "skipped" // nothing was copied
-	OutcomeDrifted        Outcome = "drifted" // dst had a different digest, overwrite=false
-	OutcomeWouldCopy      Outcome = "would-copy"
-	OutcomeWouldOverwrite Outcome = "would-overwrite"
+	StatusCopied         Status = "copied"
+	StatusOverwritten    Status = "overwritten"
+	StatusSkipped        Status = "skipped" // nothing was copied; see Reason
+	StatusDrifted        Status = "drifted" // dst had a different digest, overwrite=false
+	StatusWouldCopy      Status = "would-copy"
+	StatusWouldOverwrite Status = "would-overwrite"
+	// StatusFailed marks a failed mirror. The runner assigns it as a job's own
+	// status when the job errors (or carries a Job.PlanError); a Job never
+	// returns it as JobResult.Status, so it is excluded from validStatuses.
+	// Nested ReferrerResult rows may carry it directly when a referrer fails.
+	StatusFailed Status = "failed"
 )
 
-var validOutcomes = map[Outcome]struct{}{
-	OutcomeCopied:         {},
-	OutcomeOverwritten:    {},
-	OutcomeSkipped:        {},
-	OutcomeDrifted:        {},
-	OutcomeWouldCopy:      {},
-	OutcomeWouldOverwrite: {},
+// Reason values explain why a skipped tag or referrer was skipped. Always set
+// on a StatusSkipped result, absent otherwise.
+const (
+	ReasonUpToDate        = "up-to-date"
+	ReasonSignatureTooNew = "signature-too-new"
+)
+
+var validStatuses = map[Status]struct{}{
+	StatusCopied:         {},
+	StatusOverwritten:    {},
+	StatusSkipped:        {},
+	StatusDrifted:        {},
+	StatusWouldCopy:      {},
+	StatusWouldOverwrite: {},
 }
 
-// Valid reports whether o is one of the documented outcomes. Catches typos
-// in entry implementations (a `return "coppied"` would otherwise compile and
-// produce an unmatched outcome that's silently ignored by Render).
-func (o Outcome) Valid() bool {
-	_, ok := validOutcomes[o]
+// Valid reports whether s is one of the documented Run-returnable statuses.
+// Catches typos in entry implementations (a `return "coppied"` would otherwise
+// compile and produce an unmatched status that's silently ignored by Render).
+// StatusFailed is excluded by design: it is runner-assigned, not returned.
+func (s Status) Valid() bool {
+	_, ok := validStatuses[s]
 	return ok
 }

--- a/internal/sync/entry.go
+++ b/internal/sync/entry.go
@@ -18,8 +18,12 @@ type EntryMirror interface {
 
 // Plan is the schedulable form of an EntryMirror.
 type Plan struct {
-	// Name identifies this entry in logs and summaries (e.g. the source repo).
-	Name string
+	// Source identifies the entry's source in logs and reports (e.g. the source
+	// repo, or "<repo>/<chart>" for charts). Used as the entry's display label.
+	Source string
+	// Destination is the entry's destination repository, surfaced alongside
+	// Source in the structured report.
+	Destination string
 	// Jobs is the set of work units to execute, all bound to this entry.
 	Jobs []Job
 }

--- a/internal/sync/report.go
+++ b/internal/sync/report.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Flux Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ReportVersion pins the wire format version emitted by NewReport.
+const ReportVersion = "1.0.0"
+
+// ReportSchema is the canonical URL of the JSON Schema describing the Report shape.
+const ReportSchema = "https://raw.githubusercontent.com/fluxcd/flux-mirror/main/docs/report/schema-1.0.0.json"
+
+// Report is the envelope emitted when `flux-mirror sync` runs with
+// --output json or --output yaml. It wraps the per-entry Result with run
+// metadata (reporter, timestamp, duration) and an aggregate summary.
+type Report struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema,omitempty"`
+	Report  ReportBody `json:"report"`
+}
+
+// ReportBody holds the run metadata and results. DurationMs is the total wall
+// time in milliseconds — milliseconds rather than a Go time.Duration so it
+// marshals as a plain integer instead of opaque nanoseconds.
+type ReportBody struct {
+	Reporter   string        `json:"reporter"`
+	Timestamp  string        `json:"timestamp"`
+	DurationMs int64         `json:"durationMs"`
+	Summary    ReportSummary `json:"summary"`
+	Results    []EntryResult `json:"results"`
+}
+
+// ReportSummary aggregates per-outcome tag counts across all entries. Every
+// field is always present (zero when unused) so consumers can rely on a stable
+// key set. ExitCode is the semantic sync exit code (0 clean, 1 failures,
+// 2 drift) and is not affected by the --drift-exit-code override.
+type ReportSummary struct {
+	Entries        int `json:"entries"`
+	Copied         int `json:"copied"`
+	Overwritten    int `json:"overwritten"`
+	Skipped        int `json:"skipped"`
+	Drifted        int `json:"drifted"`
+	WouldCopy      int `json:"wouldCopy"`
+	WouldOverwrite int `json:"wouldOverwrite"`
+	Failed         int `json:"failed"`
+	ExitCode       int `json:"exitCode"`
+}
+
+// NewReport assembles a Report from a Result. The caller owns the reporter
+// string (typically "flux-mirror/"+VERSION) and the timestamp so tests can
+// pin both.
+func NewReport(reporter string, timestamp time.Time, r Result) Report {
+	counts := r.statusCounts()
+	results := r.Entries
+	if results == nil {
+		results = []EntryResult{}
+	}
+	return Report{
+		Version: ReportVersion,
+		Schema:  ReportSchema,
+		Report: ReportBody{
+			Reporter:   reporter,
+			Timestamp:  timestamp.UTC().Format(time.RFC3339),
+			DurationMs: r.Duration.Milliseconds(),
+			Summary: ReportSummary{
+				Entries:        len(r.Entries),
+				Copied:         counts[StatusCopied],
+				Overwritten:    counts[StatusOverwritten],
+				Skipped:        counts[StatusSkipped],
+				Drifted:        counts[StatusDrifted],
+				WouldCopy:      counts[StatusWouldCopy],
+				WouldOverwrite: counts[StatusWouldOverwrite],
+				Failed:         r.TotalFailures(),
+				ExitCode:       r.ExitCode(),
+			},
+			Results: results,
+		},
+	}
+}
+
+// Render writes the report to w in the requested structured format.
+// Only "yaml" and "json" are supported here; the human-readable text path
+// flows through Result.LogSummary / Result.PrettyPrint instead.
+//
+// The $schema key is JSON-only: it points at a JSON Schema document and
+// carries no meaning for YAML consumers, so it is dropped in YAML mode.
+func (rep Report) Render(w io.Writer, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	case "yaml":
+		rep.Schema = ""
+		out, err := yaml.Marshal(rep)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(out)
+		return err
+	default:
+		return fmt.Errorf("unsupported output format %q", format)
+	}
+}

--- a/internal/sync/runner.go
+++ b/internal/sync/runner.go
@@ -26,9 +26,9 @@ type Runner struct {
 	// OnJobFinished, if non-nil, is invoked once per job after Run returns.
 	// It runs from the worker goroutine (so concurrent invocations are
 	// possible — the callback must be safe to call from multiple goroutines)
-	// before the per-tag outcome is recorded, but after retries and outcome
+	// before the per-tag row is recorded, but after retries and status
 	// validation. Used by the cmd layer to drive a progress spinner.
-	OnJobFinished func(entry, id, dst string, oc Outcome, err error)
+	OnJobFinished func(entry, id, dst string, st Status, err error)
 
 	// OnEntryFinished, if non-nil, is invoked from the main goroutine once
 	// per entry, after all of that entry's jobs have completed (or its plan
@@ -79,13 +79,13 @@ func (r *Runner) Run(ctx context.Context, mirrors []EntryMirror) (res Result, er
 		}
 		entryRes, err := r.runEntry(ctx, m)
 		if err != nil {
-			// Plan-time error (couldn't list tags etc.) — record as a single
-			// entry-level failure but keep going so the rest of the config
-			// gets exercised.
+			// Plan-time error (couldn't list tags etc.) — mark the entry failed
+			// but keep going so the rest of the config gets exercised. This is
+			// the only path that sets EntryFailed; per-tag failures live as
+			// StatusFailed rows on an EntryCompleted entry.
 			r.Logger.Error("plan failed", "entry", entryRes.Name, "err", err)
-			entryRes.Failures = append(entryRes.Failures, TagFailure{
-				Tag: "<plan>", Err: err.Error(),
-			})
+			entryRes.Status = EntryFailed
+			entryRes.Error = err.Error()
 			if r.OnPlanError != nil {
 				r.OnPlanError(entryRes.Name, err)
 			}
@@ -101,11 +101,15 @@ func (r *Runner) Run(ctx context.Context, mirrors []EntryMirror) (res Result, er
 func (r *Runner) runEntry(ctx context.Context, m EntryMirror) (EntryResult, error) {
 	plan, err := m.Plan(ctx)
 	if err != nil {
-		return EntryResult{Name: plan.Name, Outcomes: map[Outcome][]string{}}, err
+		return EntryResult{Name: plan.Name, Status: EntryFailed, Tags: []TagResult{}}, err
 	}
+	// Pre-size the rows slice so each job writes to its own plan-order index
+	// regardless of completion order — output is deterministic even under
+	// concurrency. Trimmed below to the number of jobs actually launched.
 	out := EntryResult{
-		Name:     plan.Name,
-		Outcomes: map[Outcome][]string{},
+		Name:   plan.Name,
+		Status: EntryCompleted,
+		Tags:   make([]TagResult, len(plan.Jobs)),
 	}
 	r.Logger.Info("entry started", "name", plan.Name, "jobs", len(plan.Jobs))
 	defer func(start time.Time) {
@@ -113,44 +117,69 @@ func (r *Runner) runEntry(ctx context.Context, m EntryMirror) (EntryResult, erro
 			"name", plan.Name,
 			"wall", time.Since(start).Round(time.Millisecond),
 			"jobs", len(plan.Jobs),
-			"failures", len(out.Failures))
+			"failures", out.failedCount())
 	}(time.Now())
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(r.Concurrency)
 
 	var mu sync.Mutex
-	record := func(tag string, oc Outcome, err error) {
+	record := func(i int, job Job, res JobResult, err error) {
 		mu.Lock()
 		defer mu.Unlock()
-		if err != nil {
-			out.Failures = append(out.Failures, TagFailure{Tag: tag, Err: err.Error()})
-			return
+		// Digest and Referrers carry over whatever the job resolved: a
+		// copy-failed row keeps the compare digest and any referrers mirrored
+		// before the failure; a plan-failed/verify-failed row leaves both empty
+		// (zero JobResult), so the error stands alone.
+		row := TagResult{
+			Tag:          job.ID,
+			Verification: job.Verification,
+			Digest:       res.Digest,
+			Referrers:    res.Referrers,
 		}
-		out.Outcomes[oc] = append(out.Outcomes[oc], tag)
+		if err != nil {
+			row.Status = StatusFailed
+			row.Error = err.Error()
+		} else {
+			row.Status = res.Status
+			row.Reason = res.Reason
+		}
+		out.Tags[i] = row
 	}
 
-	for _, job := range plan.Jobs {
+	launched := 0
+	for i, job := range plan.Jobs {
 		if gctx.Err() != nil {
 			break
 		}
+		launched++
 		g.Go(func() error {
-			oc, err := r.runJob(gctx, job)
-			if err == nil && !oc.Valid() {
-				err = fmt.Errorf("entry returned invalid outcome %q", string(oc))
+			// A plan-time-known failure is recorded directly, skipping Run and
+			// the retry budget — retrying a guaranteed failure is wasted work.
+			res, err := JobResult{}, job.PlanError
+			if err == nil {
+				res, err = r.runJob(gctx, job)
+				if err == nil && !res.Status.Valid() {
+					err = fmt.Errorf("entry returned invalid status %q", string(res.Status))
+				}
 			}
 			if r.OnJobFinished != nil {
-				r.OnJobFinished(plan.Name, job.ID, job.Dst, oc, err)
+				r.OnJobFinished(plan.Name, job.ID, job.Dst, res.Status, err)
 			}
-			record(job.ID, oc, err)
+			record(i, job, res, err)
 			// Never propagate the error — failures are recorded per-tag and
 			// shouldn't cancel sibling tag jobs in the same entry.
 			return nil
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return out, err
+	werr := g.Wait()
+	// Trim to the prefix actually launched (jobs are launched in plan order and
+	// the loop breaks on context cancellation), so we never serialize
+	// zero-value rows for jobs that never ran.
+	out.Tags = out.Tags[:launched]
+	if werr != nil {
+		return out, werr
 	}
 	return out, nil
 }
@@ -158,24 +187,27 @@ func (r *Runner) runEntry(ctx context.Context, m EntryMirror) (EntryResult, erro
 // runJob applies the per-tag retry budget. The Run closure may be invoked
 // up to Retries+1 times within PerJobTimeout, with exponential backoff
 // between attempts. crane.Copy is idempotent so retries are safe.
-func (r *Runner) runJob(parent context.Context, job Job) (Outcome, error) {
+func (r *Runner) runJob(parent context.Context, job Job) (JobResult, error) {
 	ctx, cancel := context.WithTimeout(parent, r.PerJobTimeout)
 	defer cancel()
 
+	// Keep the last attempt's result so a copy-failed row still carries the
+	// digest/referrers the closure resolved before erroring.
+	var lastRes JobResult
 	var lastErr error
 	for attempt := 0; attempt <= r.Retries; attempt++ {
 		if err := ctx.Err(); err != nil {
 			if lastErr != nil {
-				return "", fmt.Errorf("attempts exhausted (%d) after %w; last: %w",
+				return lastRes, fmt.Errorf("attempts exhausted (%d) after %w; last: %w",
 					attempt, err, lastErr)
 			}
-			return "", err
+			return lastRes, err
 		}
-		oc, err := job.Run(ctx)
+		res, err := job.Run(ctx)
 		if err == nil {
-			return oc, nil
+			return res, nil
 		}
-		lastErr = err
+		lastRes, lastErr = res, err
 		// Don't waste the budget on a retry if the context is already done.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			break
@@ -187,9 +219,9 @@ func (r *Runner) runJob(parent context.Context, job Job) (Outcome, error) {
 			select {
 			case <-time.After(backoff):
 			case <-ctx.Done():
-				return "", ctx.Err()
+				return lastRes, ctx.Err()
 			}
 		}
 	}
-	return "", lastErr
+	return lastRes, lastErr
 }

--- a/internal/sync/runner.go
+++ b/internal/sync/runner.go
@@ -83,16 +83,16 @@ func (r *Runner) Run(ctx context.Context, mirrors []EntryMirror) (res Result, er
 			// but keep going so the rest of the config gets exercised. This is
 			// the only path that sets EntryFailed; per-tag failures live as
 			// StatusFailed rows on an EntryCompleted entry.
-			r.Logger.Error("plan failed", "entry", entryRes.Name, "err", err)
+			r.Logger.Error("plan failed", "entry", entryRes.Source, "err", err)
 			entryRes.Status = EntryFailed
 			entryRes.Error = err.Error()
 			if r.OnPlanError != nil {
-				r.OnPlanError(entryRes.Name, err)
+				r.OnPlanError(entryRes.Source, err)
 			}
 		}
 		res.Entries = append(res.Entries, entryRes)
 		if r.OnEntryFinished != nil {
-			r.OnEntryFinished(entryRes.Name)
+			r.OnEntryFinished(entryRes.Source)
 		}
 	}
 	return res, nil
@@ -101,20 +101,21 @@ func (r *Runner) Run(ctx context.Context, mirrors []EntryMirror) (res Result, er
 func (r *Runner) runEntry(ctx context.Context, m EntryMirror) (EntryResult, error) {
 	plan, err := m.Plan(ctx)
 	if err != nil {
-		return EntryResult{Name: plan.Name, Status: EntryFailed, Tags: []TagResult{}}, err
+		return EntryResult{Source: plan.Source, Destination: plan.Destination, Status: EntryFailed, Tags: []TagResult{}}, err
 	}
 	// Pre-size the rows slice so each job writes to its own plan-order index
 	// regardless of completion order — output is deterministic even under
 	// concurrency. Trimmed below to the number of jobs actually launched.
 	out := EntryResult{
-		Name:   plan.Name,
-		Status: EntryCompleted,
-		Tags:   make([]TagResult, len(plan.Jobs)),
+		Source:      plan.Source,
+		Destination: plan.Destination,
+		Status:      EntryCompleted,
+		Tags:        make([]TagResult, len(plan.Jobs)),
 	}
-	r.Logger.Info("entry started", "name", plan.Name, "jobs", len(plan.Jobs))
+	r.Logger.Info("entry started", "source", plan.Source, "jobs", len(plan.Jobs))
 	defer func(start time.Time) {
 		r.Logger.Info("entry finished",
-			"name", plan.Name,
+			"source", plan.Source,
 			"wall", time.Since(start).Round(time.Millisecond),
 			"jobs", len(plan.Jobs),
 			"failures", out.failedCount())
@@ -164,7 +165,7 @@ func (r *Runner) runEntry(ctx context.Context, m EntryMirror) (EntryResult, erro
 				}
 			}
 			if r.OnJobFinished != nil {
-				r.OnJobFinished(plan.Name, job.ID, job.Dst, res.Status, err)
+				r.OnJobFinished(plan.Source, job.ID, job.Dst, res.Status, err)
 			}
 			record(i, job, res, err)
 			// Never propagate the error — failures are recorded per-tag and

--- a/internal/sync/runner_test.go
+++ b/internal/sync/runner_test.go
@@ -23,7 +23,7 @@ type stubMirror struct {
 }
 
 func (s *stubMirror) Plan(_ context.Context) (Plan, error) {
-	return Plan{Name: s.name, Jobs: s.jobs}, s.err
+	return Plan{Source: s.name, Destination: s.name + "/dst", Jobs: s.jobs}, s.err
 }
 
 func okJob(tag string, st Status) Job {
@@ -266,8 +266,9 @@ func TestReport_Render(t *testing.T) {
 	res := Result{
 		Entries: []EntryResult{
 			{
-				Name:   "ghcr.io/foo/bar",
-				Status: EntryCompleted,
+				Source:      "ghcr.io/foo/bar",
+				Destination: "localhost:5050/bar",
+				Status:      EntryCompleted,
 				Tags: []TagResult{
 					{
 						Tag:    "v1",
@@ -347,8 +348,9 @@ func TestResult_LogSummary(t *testing.T) {
 	res := Result{
 		Entries: []EntryResult{
 			{
-				Name:   "ghcr.io/foo/bar",
-				Status: EntryCompleted,
+				Source:      "ghcr.io/foo/bar",
+				Destination: "localhost:5050/bar",
+				Status:      EntryCompleted,
 				Tags: []TagResult{
 					{Tag: "v1", Status: StatusCopied},
 					{Tag: "v2", Status: StatusCopied},
@@ -357,8 +359,9 @@ func TestResult_LogSummary(t *testing.T) {
 				},
 			},
 			{
-				Name:   "ghcr.io/foo/baz",
-				Status: EntryCompleted,
+				Source:      "ghcr.io/foo/baz",
+				Destination: "localhost:5050/baz",
+				Status:      EntryCompleted,
 				Tags: []TagResult{
 					{Tag: "v1", Status: StatusWouldCopy},
 					{Tag: "v2", Status: StatusWouldCopy},
@@ -376,11 +379,11 @@ func TestResult_LogSummary(t *testing.T) {
 	out := buf.String()
 
 	g.Expect(out).To(ContainSubstring(`msg="entry summary"`))
-	g.Expect(out).To(ContainSubstring("name=ghcr.io/foo/bar"))
+	g.Expect(out).To(ContainSubstring("source=ghcr.io/foo/bar"))
 	g.Expect(out).To(ContainSubstring("copied=2"))
 	g.Expect(out).To(ContainSubstring("skipped=1"))
 	g.Expect(out).To(ContainSubstring("drifted=1"))
-	g.Expect(out).To(ContainSubstring("name=ghcr.io/foo/baz"))
+	g.Expect(out).To(ContainSubstring("source=ghcr.io/foo/baz"))
 	g.Expect(out).To(ContainSubstring("would-copy=4"))
 	g.Expect(out).To(ContainSubstring("failed=1"))
 

--- a/internal/sync/runner_test.go
+++ b/internal/sync/runner_test.go
@@ -26,14 +26,27 @@ func (s *stubMirror) Plan(_ context.Context) (Plan, error) {
 	return Plan{Name: s.name, Jobs: s.jobs}, s.err
 }
 
-func okJob(tag string, oc Outcome) Job {
-	return Job{ID: tag, Run: func(_ context.Context) (Outcome, error) { return oc, nil }}
+func okJob(tag string, st Status) Job {
+	return Job{ID: tag, Run: func(_ context.Context) (JobResult, error) {
+		return JobResult{Status: st}, nil
+	}}
 }
 
 func failJob(tag string) Job {
-	return Job{ID: tag, Run: func(_ context.Context) (Outcome, error) {
-		return "", errors.New("boom")
+	return Job{ID: tag, Run: func(_ context.Context) (JobResult, error) {
+		return JobResult{}, errors.New("boom")
 	}}
+}
+
+// rowByTag returns the tag row with the given ID, for order-independent
+// assertions.
+func rowByTag(e EntryResult, tag string) (TagResult, bool) {
+	for _, t := range e.Tags {
+		if t.Tag == tag {
+			return t, true
+		}
+	}
+	return TagResult{}, false
 }
 
 func newRunner(t *testing.T) *Runner {
@@ -51,22 +64,31 @@ func TestRunner_AggregatesOutcomes(t *testing.T) {
 
 	mirrors := []EntryMirror{
 		&stubMirror{name: "entry-a", jobs: []Job{
-			okJob("v1", OutcomeCopied),
-			okJob("v2", OutcomeSkipped),
+			okJob("v1", StatusCopied),
+			okJob("v2", StatusSkipped),
 		}},
 		&stubMirror{name: "entry-b", jobs: []Job{
-			okJob("v1", OutcomeOverwritten),
-			okJob("v2", OutcomeDrifted),
+			okJob("v1", StatusOverwritten),
+			okJob("v2", StatusDrifted),
 		}},
 	}
 
 	res, err := r.Run(context.Background(), mirrors)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.Entries).To(HaveLen(2))
-	g.Expect(res.Entries[0].Outcomes[OutcomeCopied]).To(HaveLen(1))
-	g.Expect(res.Entries[0].Outcomes[OutcomeSkipped]).To(HaveLen(1))
-	g.Expect(res.Entries[1].Outcomes[OutcomeOverwritten]).To(HaveLen(1))
-	g.Expect(res.Entries[1].Outcomes[OutcomeDrifted]).To(Equal([]string{"v2"}))
+
+	// Rows are emitted in plan order regardless of completion order.
+	g.Expect(res.Entries[0].Status).To(Equal(EntryCompleted))
+	g.Expect(res.Entries[0].Tags).To(HaveLen(2))
+	g.Expect(res.Entries[0].Tags[0].Tag).To(Equal("v1"))
+	g.Expect(res.Entries[0].Tags[0].Status).To(Equal(StatusCopied))
+	g.Expect(res.Entries[0].Tags[1].Tag).To(Equal("v2"))
+	g.Expect(res.Entries[0].Tags[1].Status).To(Equal(StatusSkipped))
+
+	g.Expect(res.Entries[1].Tags[0].Status).To(Equal(StatusOverwritten))
+	g.Expect(res.Entries[1].Tags[1].Tag).To(Equal("v2"))
+	g.Expect(res.Entries[1].Tags[1].Status).To(Equal(StatusDrifted))
+
 	g.Expect(res.HasDrift()).To(BeTrue())
 	g.Expect(res.HasFailures()).To(BeFalse())
 	g.Expect(res.ExitCode()).To(Equal(2))
@@ -77,13 +99,22 @@ func TestRunner_FailureExitCode(t *testing.T) {
 	r := newRunner(t)
 
 	res, err := r.Run(context.Background(), []EntryMirror{
-		&stubMirror{name: "x", jobs: []Job{failJob("v1"), okJob("v2", OutcomeCopied)}},
+		&stubMirror{name: "x", jobs: []Job{failJob("v1"), okJob("v2", StatusCopied)}},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.HasFailures()).To(BeTrue())
 	g.Expect(res.ExitCode()).To(Equal(1)) // failures take precedence over anything else
-	g.Expect(res.Entries[0].Failures).To(HaveLen(1))
-	g.Expect(res.Entries[0].Outcomes[OutcomeCopied]).To(HaveLen(1))
+	g.Expect(res.TotalFailures()).To(Equal(1))
+
+	// A per-tag failure is a StatusFailed row on a still-completed entry.
+	g.Expect(res.Entries[0].Status).To(Equal(EntryCompleted))
+	failed, ok := rowByTag(res.Entries[0], "v1")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(failed.Status).To(Equal(StatusFailed))
+	g.Expect(failed.Error).To(ContainSubstring("boom"))
+	copied, ok := rowByTag(res.Entries[0], "v2")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(copied.Status).To(Equal(StatusCopied))
 }
 
 func TestRunner_PlanError(t *testing.T) {
@@ -95,7 +126,12 @@ func TestRunner_PlanError(t *testing.T) {
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(res.HasFailures()).To(BeTrue())
-	g.Expect(res.Entries[0].Failures[0].Tag).To(Equal("<plan>"))
+	g.Expect(res.TotalFailures()).To(Equal(1))
+
+	// A plan-time error marks the entry itself failed (no <plan> pseudo-tag).
+	g.Expect(res.Entries[0].Status).To(Equal(EntryFailed))
+	g.Expect(res.Entries[0].Error).To(ContainSubstring("list failed"))
+	g.Expect(res.Entries[0].Tags).To(BeEmpty())
 }
 
 func TestRunner_RetriesUntilSuccess(t *testing.T) {
@@ -104,12 +140,12 @@ func TestRunner_RetriesUntilSuccess(t *testing.T) {
 	r.Retries = 2
 
 	var attempts atomic.Int32
-	job := Job{ID: "v1", Run: func(_ context.Context) (Outcome, error) {
+	job := Job{ID: "v1", Run: func(_ context.Context) (JobResult, error) {
 		n := attempts.Add(1)
 		if n < 3 {
-			return "", errors.New("transient")
+			return JobResult{}, errors.New("transient")
 		}
-		return OutcomeCopied, nil
+		return JobResult{Status: StatusCopied}, nil
 	}}
 
 	res, err := r.Run(context.Background(), []EntryMirror{
@@ -118,7 +154,7 @@ func TestRunner_RetriesUntilSuccess(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(attempts.Load()).To(Equal(int32(3)))
 	g.Expect(res.HasFailures()).To(BeFalse())
-	g.Expect(res.Entries[0].Outcomes[OutcomeCopied]).To(HaveLen(1))
+	g.Expect(res.Entries[0].Tags[0].Status).To(Equal(StatusCopied))
 }
 
 func TestRunner_RetriesExhausted(t *testing.T) {
@@ -127,9 +163,9 @@ func TestRunner_RetriesExhausted(t *testing.T) {
 	r.Retries = 2
 
 	var attempts atomic.Int32
-	job := Job{ID: "v1", Run: func(_ context.Context) (Outcome, error) {
+	job := Job{ID: "v1", Run: func(_ context.Context) (JobResult, error) {
 		attempts.Add(1)
-		return "", errors.New("hard")
+		return JobResult{}, errors.New("hard")
 	}}
 
 	res, err := r.Run(context.Background(), []EntryMirror{
@@ -138,6 +174,7 @@ func TestRunner_RetriesExhausted(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(attempts.Load()).To(Equal(int32(3))) // retries+1
 	g.Expect(res.HasFailures()).To(BeTrue())
+	g.Expect(res.Entries[0].Tags[0].Status).To(Equal(StatusFailed))
 }
 
 func TestRunner_TimeoutBudget(t *testing.T) {
@@ -146,12 +183,12 @@ func TestRunner_TimeoutBudget(t *testing.T) {
 	r.PerJobTimeout = 100 * time.Millisecond
 	r.Retries = 5 // would do many retries if budget allowed
 
-	job := Job{ID: "v1", Run: func(ctx context.Context) (Outcome, error) {
+	job := Job{ID: "v1", Run: func(ctx context.Context) (JobResult, error) {
 		select {
 		case <-time.After(200 * time.Millisecond):
-			return OutcomeCopied, nil
+			return JobResult{Status: StatusCopied}, nil
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return JobResult{}, ctx.Err()
 		}
 	}}
 
@@ -175,7 +212,7 @@ func TestRunner_ConcurrencyBounded(t *testing.T) {
 	var maxObserved atomic.Int32
 	jobs := make([]Job, 10)
 	for i := range jobs {
-		jobs[i] = Job{ID: fmt.Sprintf("v%d", i), Run: func(_ context.Context) (Outcome, error) {
+		jobs[i] = Job{ID: fmt.Sprintf("v%d", i), Run: func(_ context.Context) (JobResult, error) {
 			n := inFlight.Add(1)
 			defer inFlight.Add(-1)
 			for {
@@ -185,14 +222,17 @@ func TestRunner_ConcurrencyBounded(t *testing.T) {
 				}
 			}
 			time.Sleep(20 * time.Millisecond)
-			return OutcomeCopied, nil
+			return JobResult{Status: StatusCopied}, nil
 		}}
 	}
 	res, err := r.Run(context.Background(), []EntryMirror{
 		&stubMirror{name: "fan-out", jobs: jobs},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Entries[0].Outcomes[OutcomeCopied]).To(HaveLen(10))
+	g.Expect(res.Entries[0].Tags).To(HaveLen(10))
+	for _, row := range res.Entries[0].Tags {
+		g.Expect(row.Status).To(Equal(StatusCopied))
+	}
 	g.Expect(maxObserved.Load()).To(BeNumerically("<=", int32(2)),
 		"errgroup.SetLimit should cap concurrent jobs")
 }
@@ -204,10 +244,10 @@ func TestRunner_EntriesAreSequential(t *testing.T) {
 
 	var order []string
 	makeJob := func(label string) Job {
-		return Job{ID: label, Run: func(_ context.Context) (Outcome, error) {
+		return Job{ID: label, Run: func(_ context.Context) (JobResult, error) {
 			time.Sleep(10 * time.Millisecond)
 			order = append(order, label)
-			return OutcomeCopied, nil
+			return JobResult{Status: StatusCopied}, nil
 		}}
 	}
 
@@ -221,34 +261,85 @@ func TestRunner_EntriesAreSequential(t *testing.T) {
 	g.Expect(order[len(order)-1]).To(Equal("b1"))
 }
 
-func TestResult_Render(t *testing.T) {
+func TestReport_Render(t *testing.T) {
 	g := NewWithT(t)
 	res := Result{
 		Entries: []EntryResult{
 			{
-				Name: "ghcr.io/foo/bar",
-				Outcomes: map[Outcome][]string{
-					OutcomeCopied:  {"v1", "v2"},
-					OutcomeSkipped: {"v4"},
+				Name:   "ghcr.io/foo/bar",
+				Status: EntryCompleted,
+				Tags: []TagResult{
+					{
+						Tag:    "v1",
+						Status: StatusCopied,
+						Digest: "sha256:1f5d3c8a9b2e47f6a0c1d8e7b4a59362f0e1d2c3b4a5968778695a4b3c2d1e0f",
+						Verification: &Verification{
+							Provider:       "cosign",
+							Issuer:         "https://token.actions.githubusercontent.com",
+							Identity:       "https://github.com/foo/bar/.github/workflows/release.yml@refs/tags/v1",
+							IntegratedTime: "2026-05-20T09:14:02Z",
+						},
+					},
+					{Tag: "v2", Status: StatusCopied},
+					{Tag: "v4", Status: StatusSkipped, Reason: ReasonUpToDate},
+					{Tag: "v3", Status: StatusDrifted},
 				},
 			},
 		},
+		Duration: 1500 * time.Millisecond,
 	}
-	res.Entries[0].Outcomes[OutcomeDrifted] = []string{"v3"}
+
+	ts := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	report := NewReport("flux-mirror/v1.2.3", ts, res)
+
+	// Envelope and summary are assembled from the Result.
+	g.Expect(report.Version).To(Equal(ReportVersion))
+	g.Expect(report.Schema).To(Equal(ReportSchema))
+	g.Expect(report.Report.Reporter).To(Equal("flux-mirror/v1.2.3"))
+	g.Expect(report.Report.Timestamp).To(Equal("2026-06-06T12:00:00Z"))
+	g.Expect(report.Report.DurationMs).To(Equal(int64(1500)))
+	g.Expect(report.Report.Summary).To(Equal(ReportSummary{
+		Entries: 1,
+		Copied:  2,
+		Skipped: 1,
+		Drifted: 1,
+		// drift with no failures classifies as exit code 2.
+		ExitCode: 2,
+	}))
 
 	for _, format := range []string{"yaml", "json"} {
 		t.Run(format, func(t *testing.T) {
 			g := NewWithT(t)
 			var buf bytes.Buffer
-			g.Expect(res.Render(&buf, format)).To(Succeed())
+			g.Expect(report.Render(&buf, format)).To(Succeed())
 			g.Expect(buf.String()).ToNot(BeEmpty())
 			g.Expect(buf.String()).To(ContainSubstring("ghcr.io/foo/bar"))
+			g.Expect(buf.String()).To(ContainSubstring("flux-mirror/v1.2.3"))
+			// Verification metadata is rendered on the row.
+			g.Expect(buf.String()).To(ContainSubstring("token.actions.githubusercontent.com"))
 		})
 	}
 
+	// $schema is JSON-only; YAML consumers don't use it.
+	var jsonBuf, yamlBuf bytes.Buffer
+	g.Expect(report.Render(&jsonBuf, "json")).To(Succeed())
+	g.Expect(jsonBuf.String()).To(ContainSubstring(`"$schema"`))
+	g.Expect(report.Render(&yamlBuf, "yaml")).To(Succeed())
+	g.Expect(yamlBuf.String()).ToNot(ContainSubstring("$schema"))
+
 	var buf bytes.Buffer
-	g.Expect(res.Render(&buf, "text")).To(MatchError(ContainSubstring("unsupported")))
-	g.Expect(res.Render(&buf, "xml")).To(MatchError(ContainSubstring("unsupported")))
+	g.Expect(report.Render(&buf, "text")).To(MatchError(ContainSubstring("unsupported")))
+	g.Expect(report.Render(&buf, "xml")).To(MatchError(ContainSubstring("unsupported")))
+}
+
+// NewReport must emit results as an empty array, never null, so consumers can
+// always range over report.results.
+func TestReport_EmptyResults(t *testing.T) {
+	g := NewWithT(t)
+	report := NewReport("flux-mirror/v1.2.3", time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC), Result{})
+	var buf bytes.Buffer
+	g.Expect(report.Render(&buf, "json")).To(Succeed())
+	g.Expect(buf.String()).To(ContainSubstring(`"results": []`))
 }
 
 func TestResult_LogSummary(t *testing.T) {
@@ -256,19 +347,25 @@ func TestResult_LogSummary(t *testing.T) {
 	res := Result{
 		Entries: []EntryResult{
 			{
-				Name: "ghcr.io/foo/bar",
-				Outcomes: map[Outcome][]string{
-					OutcomeCopied:  {"v1", "v2"},
-					OutcomeSkipped: {"v4"},
-					OutcomeDrifted: {"v3"},
+				Name:   "ghcr.io/foo/bar",
+				Status: EntryCompleted,
+				Tags: []TagResult{
+					{Tag: "v1", Status: StatusCopied},
+					{Tag: "v2", Status: StatusCopied},
+					{Tag: "v4", Status: StatusSkipped, Reason: ReasonUpToDate},
+					{Tag: "v3", Status: StatusDrifted},
 				},
 			},
 			{
-				Name: "ghcr.io/foo/baz",
-				Outcomes: map[Outcome][]string{
-					OutcomeWouldCopy: {"v1", "v2", "v3", "v4"},
+				Name:   "ghcr.io/foo/baz",
+				Status: EntryCompleted,
+				Tags: []TagResult{
+					{Tag: "v1", Status: StatusWouldCopy},
+					{Tag: "v2", Status: StatusWouldCopy},
+					{Tag: "v3", Status: StatusWouldCopy},
+					{Tag: "v4", Status: StatusWouldCopy},
+					{Tag: "v5", Status: StatusFailed, Error: "boom"},
 				},
-				Failures: []TagFailure{{Tag: "v1", Err: "boom"}},
 			},
 		},
 	}

--- a/internal/sync/summary.go
+++ b/internal/sync/summary.go
@@ -4,39 +4,85 @@
 package sync
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
 	"time"
-
-	"sigs.k8s.io/yaml"
 )
 
 // Result is the aggregate output of Runner.Run. Duration is the total wall
-// time the run took (set by the runner) and is excluded from the structured
-// JSON/YAML output — those are meant for programmatic consumers, where a
-// Go time.Duration would marshal as opaque nanoseconds.
+// time the run took (set by the runner) and is excluded from the per-entry
+// JSON/YAML output — the structured Report (see NewReport) surfaces it as a
+// plain millisecond integer instead, since a Go time.Duration would marshal
+// as opaque nanoseconds.
 type Result struct {
 	Entries  []EntryResult `json:"entries"`
 	Duration time.Duration `json:"-"`
 }
 
-// EntryResult is the per-entry slice of a Result. Outcomes maps each
-// outcome to the list of tag IDs that landed in that bucket; the count is
-// just `len(Outcomes[oc])`. Failures are tracked separately because they
-// carry an error message alongside the tag.
+// EntryStatus is the entry-level outcome. It answers "was the entry planned
+// and run, or did it abort at plan time" — distinct from the per-tag Status.
+type EntryStatus string
+
+const (
+	// EntryCompleted means the entry produced a plan and ran. Its Tags may be
+	// empty (nothing matched the selector) or contain StatusFailed rows
+	// (per-tag problems) — neither makes the entry itself a failure.
+	EntryCompleted EntryStatus = "completed"
+	// EntryFailed means the entry could not be planned (e.g. ListTags
+	// rejected). Error carries the plan-time message and Tags is empty.
+	EntryFailed EntryStatus = "failed"
+)
+
+// EntryResult is the per-entry slice of a Result. Each tag job becomes a
+// TagResult row carrying its own status, digest, skip reason, error, and
+// referrers — so verification and per-tag detail are expressible without a
+// side channel. Status disambiguates an empty Tags array (nothing matched vs
+// plan failed).
 type EntryResult struct {
-	Name     string               `json:"name"`
-	Outcomes map[Outcome][]string `json:"outcomes"`
-	Failures []TagFailure         `json:"failures,omitempty"`
+	Name   string      `json:"name"`
+	Status EntryStatus `json:"status"`
+	Error  string      `json:"error,omitempty"`
+	Tags   []TagResult `json:"tags"`
 }
 
-// TagFailure records a single per-tag failure with its error string.
-type TagFailure struct {
-	Tag string `json:"tag"`
-	Err string `json:"err"`
+// TagResult is one tag's row in the report. Optional fields follow the wire
+// contract: digest when resolved; reason only on skipped; error only on
+// failed; referrers only when includeReferrers surfaced any; verification only
+// when a signature was confirmed.
+type TagResult struct {
+	Tag          string           `json:"tag"`
+	Status       Status           `json:"status"`
+	Digest       string           `json:"digest,omitempty"`
+	Reason       string           `json:"reason,omitempty"`
+	Error        string           `json:"error,omitempty"`
+	Referrers    []ReferrerResult `json:"referrers,omitempty"`
+	Verification *Verification    `json:"verification,omitempty"`
+}
+
+// ReferrerResult is one mirrored referrer (cosign signature bundle, SBOM,
+// attestation) of a tag. It reuses the per-tag Status enum; Reason is set to
+// up-to-date on a skipped referrer (same always-on-skip rule as tags).
+type ReferrerResult struct {
+	Digest       string `json:"digest"`
+	ArtifactType string `json:"artifactType,omitempty"`
+	Status       Status `json:"status"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// Verification is the signature verification metadata recorded on a tag row.
+// Only Provider is guaranteed; everything else is best-effort and omitted when
+// empty: Issuer/Identity are set when the keyless cert identity is recovered;
+// IntegratedTime only when the bundle carries a verified transparency-log
+// timestamp; Age/MinAge only on the signature-too-new skip.
+type Verification struct {
+	Provider       string `json:"provider"`
+	Issuer         string `json:"issuer,omitempty"`
+	Identity       string `json:"identity,omitempty"`
+	IntegratedTime string `json:"integratedTime,omitempty"`
+	Age            string `json:"age,omitempty"`
+	MinAge         string `json:"minAge,omitempty"`
 }
 
 // HasFailures reports whether any tag job failed across all entries.
@@ -44,20 +90,24 @@ func (r Result) HasFailures() bool {
 	return r.TotalFailures() > 0
 }
 
-// TotalFailures sums per-entry failure counts.
+// TotalFailures sums per-tag StatusFailed rows plus plan-failed entries.
 func (r Result) TotalFailures() int {
 	n := 0
 	for _, e := range r.Entries {
-		n += len(e.Failures)
+		n += e.failedCount()
 	}
 	return n
 }
 
-// TotalDrifted sums per-entry drift counts.
+// TotalDrifted sums per-tag drift counts.
 func (r Result) TotalDrifted() int {
 	n := 0
 	for _, e := range r.Entries {
-		n += len(e.Outcomes[OutcomeDrifted])
+		for _, t := range e.Tags {
+			if t.Status == StatusDrifted {
+				n++
+			}
+		}
 	}
 	return n
 }
@@ -85,46 +135,19 @@ func (r Result) ExitCode() int {
 	return 0
 }
 
-// Render writes the result to w in the requested structured format.
-// Only "yaml" and "json" are supported here; the human-readable text path
-// flows through LogSummary so it shares the runner's log formatting.
-func (r Result) Render(w io.Writer, format string) error {
-	switch format {
-	case "yaml":
-		out, err := yaml.Marshal(r)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(out)
-		return err
-	case "json":
-		out, err := json.MarshalIndent(r, "", "  ")
-		if err != nil {
-			return err
-		}
-		if _, err := w.Write(out); err != nil {
-			return err
-		}
-		_, err = io.WriteString(w, "\n")
-		return err
-	default:
-		return fmt.Errorf("unsupported output format %q", format)
-	}
-}
-
 // PrettyPrint writes a one-line totals summary to w. Used in pretty-print
 // (non-verbose, text-output) mode, below the per-tag completion lines —
 // which already enumerate the tags, so the summary itself stays tight.
-// Zero-valued outcome buckets are omitted; an empty run renders as
+// Zero-valued status buckets are omitted; an empty run renders as
 // "Summary: nothing to mirror.".
 func (r Result) PrettyPrint(w io.Writer) error {
-	tagsByOutcome := r.tagsByOutcome()
+	counts := r.statusCounts()
 	failed := r.TotalFailures()
 
 	parts := make([]string, 0, len(prettyPrintOrder)+1)
-	for _, oc := range prettyPrintOrder {
-		if n := len(tagsByOutcome[oc]); n > 0 {
-			parts = append(parts, fmt.Sprintf("%d %s", n, oc))
+	for _, st := range prettyPrintOrder {
+		if n := counts[st]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, st))
 		}
 	}
 	if failed > 0 {
@@ -149,76 +172,99 @@ func (r Result) PrettyPrint(w io.Writer) error {
 // "sync complete" total, all through the supplied logger so they share
 // the same timestamp/format as the per-tag progress logs above them.
 func (r Result) LogSummary(logger *slog.Logger) {
-	totals := map[Outcome]int{}
-	totalFailed := 0
+	totals := map[Status]int{}
 	for _, e := range r.Entries {
 		logger.Info("entry summary", entryAttrs(e)...)
-		for k, v := range e.Outcomes {
-			totals[k] += len(v)
+		for st, n := range e.statusCounts() {
+			if st == StatusFailed {
+				continue
+			}
+			totals[st] += n
 		}
-		totalFailed += len(e.Failures)
 	}
-	logger.Info("sync complete", totalAttrs(len(r.Entries), totals, totalFailed, r.Duration)...)
+	logger.Info("sync complete", totalAttrs(len(r.Entries), totals, r.TotalFailures(), r.Duration)...)
 }
 
-// tagsByOutcome flattens per-entry tag lists into a single map across the
-// whole result, preserving the order tags were recorded in.
-func (r Result) tagsByOutcome() map[Outcome][]string {
-	out := map[Outcome][]string{}
+// statusCounts tallies non-failed tag rows by status across the whole result.
+func (r Result) statusCounts() map[Status]int {
+	out := map[Status]int{}
 	for _, e := range r.Entries {
-		for oc, tags := range e.Outcomes {
-			out[oc] = append(out[oc], tags...)
+		for st, n := range e.statusCounts() {
+			if st == StatusFailed {
+				continue
+			}
+			out[st] += n
 		}
 	}
 	return out
 }
 
-// summaryOrder pins the key order so log lines are stable for grep/diff.
-// would-* keys are appended only when present (dry-run only).
-var summaryOrder = []Outcome{
-	OutcomeCopied,
-	OutcomeOverwritten,
-	OutcomeSkipped,
-	OutcomeDrifted,
+// statusCounts tallies this entry's tag rows by status (including StatusFailed).
+func (e EntryResult) statusCounts() map[Status]int {
+	counts := map[Status]int{}
+	for _, t := range e.Tags {
+		counts[t.Status]++
+	}
+	return counts
 }
 
-// prettyPrintOrder controls the order outcomes appear in the Summary
-// block of PrettyPrint: action-y outcomes first, drift last, dry-run
+// failedCount is the entry's contribution to the failure total: its
+// StatusFailed tag rows, plus one when the entry itself failed at plan time.
+func (e EntryResult) failedCount() int {
+	n := e.statusCounts()[StatusFailed]
+	if e.Status == EntryFailed {
+		n++
+	}
+	return n
+}
+
+// summaryOrder pins the key order so log lines are stable for grep/diff.
+// would-* keys are appended only when present (dry-run only).
+var summaryOrder = []Status{
+	StatusCopied,
+	StatusOverwritten,
+	StatusSkipped,
+	StatusDrifted,
+}
+
+// prettyPrintOrder controls the order statuses appear in the Summary
+// block of PrettyPrint: action-y statuses first, drift last, dry-run
 // forecasts appended.
-var prettyPrintOrder = []Outcome{
-	OutcomeCopied,
-	OutcomeOverwritten,
-	OutcomeSkipped,
-	OutcomeDrifted,
-	OutcomeWouldCopy,
-	OutcomeWouldOverwrite,
+var prettyPrintOrder = []Status{
+	StatusCopied,
+	StatusOverwritten,
+	StatusSkipped,
+	StatusDrifted,
+	StatusWouldCopy,
+	StatusWouldOverwrite,
 }
 
 func entryAttrs(e EntryResult) []any {
+	counts := e.statusCounts()
 	attrs := []any{"name", e.Name}
-	for _, oc := range summaryOrder {
-		attrs = append(attrs, string(oc), len(e.Outcomes[oc]))
+	for _, st := range summaryOrder {
+		attrs = append(attrs, string(st), counts[st])
 	}
-	if n := len(e.Outcomes[OutcomeWouldCopy]); n > 0 {
-		attrs = append(attrs, string(OutcomeWouldCopy), n)
+	if n := counts[StatusWouldCopy]; n > 0 {
+		attrs = append(attrs, string(StatusWouldCopy), n)
 	}
-	if n := len(e.Outcomes[OutcomeWouldOverwrite]); n > 0 {
-		attrs = append(attrs, string(OutcomeWouldOverwrite), n)
+	if n := counts[StatusWouldOverwrite]; n > 0 {
+		attrs = append(attrs, string(StatusWouldOverwrite), n)
 	}
-	attrs = append(attrs, "failed", len(e.Failures))
+	attrs = append(attrs, "failed", e.failedCount())
 	return attrs
 }
 
-func totalAttrs(entries int, totals map[Outcome]int, failed int, duration time.Duration) []any {
+func totalAttrs(entries int, totals map[Status]int, failed int, duration time.Duration) []any {
 	attrs := []any{"entries", entries}
-	for _, oc := range summaryOrder {
-		attrs = append(attrs, string(oc), totals[oc])
+	for _, st := range summaryOrder {
+		attrs = append(attrs, string(st), totals[st])
 	}
-	if n := totals[OutcomeWouldCopy]; n > 0 {
-		attrs = append(attrs, string(OutcomeWouldCopy), n)
+	if n := totals[StatusWouldCopy]; n > 0 {
+		attrs = append(attrs, string(StatusWouldCopy), n)
 	}
-	if n := totals[OutcomeWouldOverwrite]; n > 0 {
-		attrs = append(attrs, string(OutcomeWouldOverwrite), n)
+	if n := totals[StatusWouldOverwrite]; n > 0 {
+		attrs = append(attrs, string(StatusWouldOverwrite), n)
 	}
 	attrs = append(attrs, "failed", failed)
 	if duration > 0 {

--- a/internal/sync/summary.go
+++ b/internal/sync/summary.go
@@ -41,10 +41,11 @@ const (
 // side channel. Status disambiguates an empty Tags array (nothing matched vs
 // plan failed).
 type EntryResult struct {
-	Name   string      `json:"name"`
-	Status EntryStatus `json:"status"`
-	Error  string      `json:"error,omitempty"`
-	Tags   []TagResult `json:"tags"`
+	Source      string      `json:"source"`
+	Destination string      `json:"destination"`
+	Status      EntryStatus `json:"status"`
+	Error       string      `json:"error,omitempty"`
+	Tags        []TagResult `json:"tags"`
 }
 
 // TagResult is one tag's row in the report. Optional fields follow the wire
@@ -241,7 +242,7 @@ var prettyPrintOrder = []Status{
 
 func entryAttrs(e EntryResult) []any {
 	counts := e.statusCounts()
-	attrs := []any{"name", e.Name}
+	attrs := []any{"source", e.Source}
 	for _, st := range summaryOrder {
 		attrs = append(attrs, string(st), counts[st])
 	}

--- a/test/podinfo.sh
+++ b/test/podinfo.sh
@@ -70,14 +70,17 @@ echo ""
 echo "==> Re-running sync (idempotency check)"
 SYNC_OUT=$("${BIN}" sync "${CONFIG}" --insecure -o json)
 
-NON_SKIPPED=$(echo "${SYNC_OUT}" | jq '[.entries[] | .outcomes | to_entries[] | select(.key != "skipped")] | length')
-if [[ "${NON_SKIPPED}" -ne 0 ]]; then
-  echo "FAIL: expected all outcomes to be skipped on re-sync" >&2
+# Every entry must have completed at plan time, and every tag and referrer row
+# must be skipped (nothing copied/overwritten/drifted/failed on the re-run).
+NOT_COMPLETED=$(echo "${SYNC_OUT}" | jq '[.report.results[] | select(.status != "completed")] | length')
+NON_SKIPPED=$(echo "${SYNC_OUT}" | jq '[.report.results[].tags[] | .status, (.referrers[]? | .status) | select(. != "skipped")] | length')
+if [[ "${NOT_COMPLETED}" -ne 0 || "${NON_SKIPPED}" -ne 0 ]]; then
+  echo "FAIL: expected all rows to be skipped on re-sync" >&2
   echo "${SYNC_OUT}" | jq . >&2
   exit 1
 fi
 
-SKIPPED=$(echo "${SYNC_OUT}" | jq '[.entries[].outcomes.skipped[]] | length')
+SKIPPED=$(echo "${SYNC_OUT}" | jq '[.report.results[].tags[] | select(.status == "skipped")] | length')
 echo "  all ${SKIPPED} tags skipped"
 
 echo ""


### PR DESCRIPTION
Implement structured report for the `flux-mirror sync --output json|yaml`. 

Example:

```json
{
  "version": "1.0.0",
  "$schema": "https://raw.githubusercontent.com/fluxcd/flux-mirror/main/docs/report/schema-1.0.0.json",
  "report": {
    "reporter": "flux-mirror/v0.1.0",
    "timestamp": "2026-06-06T20:12:25Z",
    "durationMs": 16724,
    "summary": {
      "entries": 2,
      "copied": 1,
      "overwritten": 0,
      "skipped": 1,
      "drifted": 0,
      "wouldCopy": 0,
      "wouldOverwrite": 0,
      "failed": 1,
      "exitCode": 1
    },
    "results": [
      {
        "source": "docker.io/stefanprodan/podinfo",
        "destination": "localhost:5050/podinfo",
        "status": "completed",
        "tags": [
          {
            "tag": "6.13.0",
            "status": "skipped",
            "digest": "sha256:7bdd8cc80b64377b05f5c0a51604c028ed6adea4beaca2e766b9325efa52916c",
            "reason": "signature-too-new",
            "verification": {
              "provider": "cosign",
              "issuer": "https://token.actions.githubusercontent.com",
              "identity": "https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.13.0",
              "integratedTime": "2026-06-04T20:59:02Z",
              "age": "47h13m11s",
              "minAge": "48h0m0s"
            }
          },
          {
            "tag": "6.12.0",
            "status": "copied",
            "digest": "sha256:453e2238f70c00dfba6803ddb99a4bb86982ee549f7273f43f90ac58f0714a81",
            "referrers": [
              {
                "digest": "sha256:5892f840c5013230cd0b63fdd5076dd9fe3224a31bd3ebae5c723e3632100b0f",
                "artifactType": "application/vnd.dev.sigstore.bundle.v0.3+json",
                "status": "copied"
              }
            ],
            "verification": {
              "provider": "cosign",
              "issuer": "https://token.actions.githubusercontent.com",
              "identity": "https://github.com/stefanprodan/podinfo/.github/workflows/release.yml@refs/tags/6.12.0",
              "integratedTime": "2026-05-20T10:16:39Z"
            }
          }
        ]
      },
      {
        "source": "docker.io/library/flux-mirror-nonexistent-zzz",
        "destination": "localhost:5050/nonexistent",
        "status": "failed",
        "error": "list tags docker.io/library/flux-mirror-nonexistent-zzz: GET https://index.docker.io/v2/library/flux-mirror-nonexistent-zzz/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/flux-mirror-nonexistent-zzz Type:repository]]",
        "tags": []
      }
    ]
  }
}
```