### PR TITLE
Fix stale config docs in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ flux-mirror sync flux-mirror.yaml --no-progress --drift-exit-code=0
 For downstream tooling, emit a structured report:
 
 ```shell
-flux-mirror sync flux-mirror.yaml -o json | jq '.entries[].outcomes'
+flux-mirror sync flux-mirror.yaml -o json | jq '.report.results[].tags'
 ```
 
 ### GitHub Actions

--- a/cmd/flux-mirror/main_test.go
+++ b/cmd/flux-mirror/main_test.go
@@ -52,6 +52,7 @@ func resetCmdArgs() {
 	versionArgs = versionFlags{output: "text"}
 	syncArgs = syncFlags{output: "text", concurrency: 4, retries: 3, driftExitCode: syncDefaultDriftExitCode}
 	loginArgs = loginFlags{}
+	secretArgs = secretFlags{}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
 	// which breaks MarkFlagRequired validation in subsequent tests. Clear it

--- a/cmd/flux-mirror/secret.go
+++ b/cmd/flux-mirror/secret.go
@@ -48,8 +48,9 @@ CronJob. Pass --create to instead fail if the Secret already exists, matching
 'kubectl create secret docker-registry'.
 
 By default every host in the config is included; restrict with one or more
---host flags. The config is read from --config (default ~/.flux-mirror/config.yaml,
-or '-' for stdin). The cluster, namespace, and credentials are resolved from the
+--host flags. The config is read from --config, else $FLUX_MIRROR_CONFIG,
+else a path derived from the executable location ('-' reads the config from
+stdin). The cluster, namespace, and credentials are resolved from the
 standard kubectl flags and env vars, working both with a local kubeconfig and
 in-cluster.`,
 	Example: `  # Upsert a Secret for all hosts in the default config, in the current namespace

--- a/cmd/flux-mirror/secret_test.go
+++ b/cmd/flux-mirror/secret_test.go
@@ -108,3 +108,12 @@ func TestApplySecret_CreateOnlyConflict(t *testing.T) {
 	g.Expect(json.Unmarshal(got.Data[corev1.DockerConfigJsonKey], &parsed)).To(Succeed())
 	g.Expect(parsed.Auths["a.example"].Password).To(Equal("v1"))
 }
+
+func TestSecretHelp_UsesSharedConfigDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	out, err := executeCommand([]string{"secret", "--help"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("else $FLUX_MIRROR_CONFIG"))
+	g.Expect(out).ToNot(ContainSubstring("~/.flux-mirror/config.yaml"))
+}


### PR DESCRIPTION
Tiny docs fix, but it trips right away.

`flux-mirror secret --help` said the default config was `~/.flux-mirror/config.yaml`. In practice the command uses `--config`, then `FLUX_MIRROR_CONFIG`, then `<executable>.config`. The README also still showed `jq '.entries[].outcomes'`, but the current report shape is `.report.results[].tags`

Repro
1. `go run ./cmd/flux-mirror secret --help`
2. Compare the long help text with the `-f, --config` flag help
3. Run `flux-mirror sync config.yaml -o json | jq '.entries[].outcomes'`
4. `jq` returns `null`, bc those keys are gone

Fix
1. Use the shared config path wording in `secret` help
2. Update the README `jq` example
3. Add a small regression test for `secret --help`
