### PR TITLE
Fix sync timeout help default

### DIFF
--- a/cmd/flux-mirror/main_test.go
+++ b/cmd/flux-mirror/main_test.go
@@ -50,20 +50,36 @@ func resetCmdArgs() {
 	rootCmd.SetIn(os.Stdin)
 
 	versionArgs = versionFlags{output: "text"}
-	syncArgs = syncFlags{output: "text", concurrency: 4, retries: 3, driftExitCode: syncDefaultDriftExitCode}
+	syncArgs = syncFlags{
+		output:        "text",
+		concurrency:   4,
+		timeout:       syncDefaultTimeout,
+		retries:       3,
+		driftExitCode: syncDefaultDriftExitCode,
+	}
 	loginArgs = loginFlags{}
 	secretArgs = secretFlags{}
 
 	// pflag.Flag.Changed persists across Execute calls on the shared rootCmd,
-	// which breaks MarkFlagRequired validation in subsequent tests. Clear it
-	// for every flag in the command tree.
-	resetFlagChanged(rootCmd)
+	// and some bool flag values (notably --help=true) also persist. Reset the
+	// bool flags in the command tree to their default state for test isolation;
+	// the command arg structs above handle the non-bool flag values.
+	resetFlags(rootCmd)
 }
 
-func resetFlagChanged(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+func resetFlags(cmd *cobra.Command) {
+	resetFlagSet(cmd.Flags())
+	resetFlagSet(cmd.PersistentFlags())
 	for _, sub := range cmd.Commands() {
-		resetFlagChanged(sub)
+		resetFlags(sub)
 	}
+}
+
+func resetFlagSet(fs *pflag.FlagSet) {
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Value.Type() == "bool" {
+			_ = f.Value.Set(f.DefValue)
+		}
+		f.Changed = false
+	})
 }

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -40,7 +40,7 @@ var syncCmd = &cobra.Command{
 declarative YAML config (apiVersion: mirror.fluxcd.io/v1alpha1, kind: Config).
 OCI registry auth is read from the ambient Docker config (~/.docker/config.json,
 $DOCKER_CONFIG, and configured credential helpers), or, for hosts listed in the
-config's 'auth' section, from a per-host JWT. Helm HTTP/S repository auth is read
+config's 'hosts' section, from a per-host JWT. Helm HTTP/S repository auth is read
 from Helm's default repositories.yaml path, or $HELM_REPOSITORY_CONFIG when set.
 
 Exit codes:
@@ -71,6 +71,7 @@ destination registry is known to be immutable.`,
 type syncFlags struct {
 	output        flags.Output
 	concurrency   int
+	timeout       time.Duration
 	retries       int
 	overwrite     bool
 	driftExitCode int
@@ -84,6 +85,7 @@ type syncFlags struct {
 var syncArgs = syncFlags{
 	output:        "text",
 	concurrency:   4,
+	timeout:       syncDefaultTimeout,
 	retries:       3,
 	driftExitCode: syncDefaultDriftExitCode,
 }
@@ -92,6 +94,8 @@ func init() {
 	syncCmd.Flags().VarP(&syncArgs.output, "output", "o", syncArgs.output.Description())
 	syncCmd.Flags().IntVar(&syncArgs.concurrency, "concurrency", syncArgs.concurrency,
 		"Maximum number of copy operations to run in parallel per job")
+	syncCmd.Flags().DurationVar(&syncArgs.timeout, "timeout", syncArgs.timeout,
+		"The length of time to wait before giving up on the current operation.")
 	syncCmd.Flags().IntVar(&syncArgs.retries, "retries", syncArgs.retries,
 		"Maximum number of retry attempts per job within timeout budget.")
 	syncCmd.Flags().BoolVar(&syncArgs.overwrite, "overwrite", false,
@@ -128,12 +132,7 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Bump per-job timeout to 5m if the user didn't pass --timeout explicitly.
-	// The root flag's declared default stays at 1m so other commands aren't
-	// affected.
-	if !cmd.Flags().Changed("timeout") {
-		rootArgs.timeout = syncDefaultTimeout
-	}
+	timeout := resolveSyncTimeout(cmd)
 
 	// Verbose enables our own structured logs (sync started, entry started,
 	// mirroring tag, tag done, entry summary, sync complete) AND wires
@@ -172,7 +171,7 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 	runner := &sync.Runner{
 		Concurrency:   syncArgs.concurrency,
 		Retries:       syncArgs.retries,
-		PerJobTimeout: rootArgs.timeout,
+		PerJobTimeout: timeout,
 		Logger:        logger,
 	}
 
@@ -242,6 +241,16 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return classifyExit(res, syncArgs.driftExitCode)
+}
+
+func resolveSyncTimeout(cmd *cobra.Command) time.Duration {
+	timeout := syncArgs.timeout
+	if !cmd.Flags().Changed("timeout") {
+		if f := rootCmd.PersistentFlags().Lookup("timeout"); f != nil && f.Changed {
+			timeout = rootArgs.timeout
+		}
+	}
+	return timeout
 }
 
 // syncExitError is returned to make `main` exit with a code other than 1

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 	. "github.com/onsi/gomega"
@@ -348,6 +349,58 @@ func TestSync_DriftExitCodeValidation(t *testing.T) {
 	_, err := executeCommand([]string{"sync", cfgPath, "--drift-exit-code", "-1"})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("--drift-exit-code must be between 0 and 255"))
+}
+
+func TestSyncHelp_UsesEffectiveTimeoutDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	out, err := executeCommand([]string{"sync", "--help"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(ContainSubstring("config's 'hosts' section"))
+	g.Expect(out).ToNot(ContainSubstring("config's 'auth' section"))
+	g.Expect(out).To(ContainSubstring("--timeout duration"))
+	g.Expect(out).To(ContainSubstring("(default 5m0s)"))
+}
+
+func TestResolveSyncTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*testing.T)
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "sync default stays at five minutes",
+			wantTimeout: 5 * time.Minute,
+		},
+		{
+			name: "sync local timeout overrides default",
+			setup: func(t *testing.T) {
+				t.Helper()
+				_ = syncCmd.Flags().Set("timeout", "7m")
+			},
+			wantTimeout: 7 * time.Minute,
+		},
+		{
+			name: "root timeout before subcommand is still honored",
+			setup: func(t *testing.T) {
+				t.Helper()
+				_ = rootCmd.PersistentFlags().Set("timeout", "9m")
+			},
+			wantTimeout: 9 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			defer resetCmdArgs()
+
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+			g.Expect(resolveSyncTimeout(syncCmd)).To(Equal(tt.wantTimeout))
+		})
+	}
 }
 
 func TestSync_DryRun(t *testing.T) {


### PR DESCRIPTION
Tiny help/docs papercut, pretty easy repro

`flux-mirror sync --help` said `--timeout` defaults to `1m0s`, but `sync` actually uses `5m` when no timeout is passed. So the help text was just wrong. It also said the config `auth` section, but the field is `hosts`

Repro
1. Build current `main`
2. Run `flux-mirror sync --help`
3. See `Global Flags` show `--timeout duration ... (default 1m0s)`

This patch gives `sync` its effective `--timeout` default in help, keeps root level `--timeout` working too, and adds coverage for timeout precedence plus the help flag state leak in tests

