### PR TITLE
Simplify TLS/SPIFFE validation and source handling

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,18 @@ func validateHost(h apiv1.RegistryHost) error {
 	return nil
 }
 
+// countTrue counts how many of the given conditions are true. It is used by the
+// "exactly one of ..." validators below.
+func countTrue(conds ...bool) int {
+	n := 0
+	for _, c := range conds {
+		if c {
+			n++
+		}
+	}
+	return n
+}
+
 // validateTLS checks the TLS settings: at least one of serverAuth or clientAuth
 // must be set, and each (if set) must itself be valid.
 func validateTLS(t apiv1.TLS) error {
@@ -189,18 +201,12 @@ func validateTLS(t apiv1.TLS) error {
 // validateTLSServerAuth checks that exactly one of the CA-bundle sources or
 // spiffe is set.
 func validateTLSServerAuth(s apiv1.TLSServerAuth) error {
-	n := 0
-	for _, set := range []bool{
+	if countTrue(
 		strings.TrimSpace(s.FromPath) != "",
 		strings.TrimSpace(s.FromEnv) != "",
 		strings.TrimSpace(s.FromBytes) != "",
 		s.SPIFFE != nil,
-	} {
-		if set {
-			n++
-		}
-	}
-	if n != 1 {
+	) != 1 {
 		return fmt.Errorf("exactly one of fromPath, fromEnv, fromBytes, or spiffe must be set")
 	}
 	if s.SPIFFE != nil {
@@ -213,17 +219,11 @@ func validateTLSServerAuth(s apiv1.TLSServerAuth) error {
 
 // validateTLSData checks that exactly one source is set.
 func validateTLSData(d apiv1.TLSData) error {
-	n := 0
-	for _, set := range []bool{
+	if countTrue(
 		strings.TrimSpace(d.FromPath) != "",
 		strings.TrimSpace(d.FromEnv) != "",
 		strings.TrimSpace(d.FromBytes) != "",
-	} {
-		if set {
-			n++
-		}
-	}
-	if n != 1 {
+	) != 1 {
 		return fmt.Errorf("exactly one of fromPath, fromEnv, or fromBytes must be set")
 	}
 	return nil
@@ -232,16 +232,10 @@ func validateTLSData(d apiv1.TLSData) error {
 // validateTLSKey checks that exactly one source is set. A private key cannot be
 // inlined.
 func validateTLSKey(k apiv1.TLSKey) error {
-	n := 0
-	for _, set := range []bool{
+	if countTrue(
 		strings.TrimSpace(k.FromPath) != "",
 		strings.TrimSpace(k.FromEnv) != "",
-	} {
-		if set {
-			n++
-		}
-	}
-	if n != 1 {
+	) != 1 {
 		return fmt.Errorf("exactly one of fromPath or fromEnv must be set")
 	}
 	return nil
@@ -281,13 +275,7 @@ func validateSPIFFE(s apiv1.SPIFFETLS) error {
 	serverID := strings.TrimSpace(s.ServerID)
 	trustDomain := strings.TrimSpace(s.TrustDomain)
 
-	n := 0
-	for _, set := range []bool{serverID != "", trustDomain != "", s.AuthorizeAny} {
-		if set {
-			n++
-		}
-	}
-	if n != 1 {
+	if countTrue(serverID != "", trustDomain != "", s.AuthorizeAny) != 1 {
 		return fmt.Errorf("exactly one of serverID, trustDomain, or authorizeAny must be set")
 	}
 	if serverID != "" {
@@ -309,13 +297,7 @@ func validateCredential(j apiv1.RegistryCredential) error {
 	fromPath := strings.TrimSpace(j.FromPath)
 	jwkPath := strings.TrimSpace(j.JWKPath)
 
-	n := 0
-	for _, set := range []bool{provider != "", fromEnv != "", fromPath != "", jwkPath != ""} {
-		if set {
-			n++
-		}
-	}
-	if n != 1 {
+	if countTrue(provider != "", fromEnv != "", fromPath != "", jwkPath != "") != 1 {
 		return fmt.Errorf("exactly one of provider, fromEnv, fromPath, or jwkPath must be set")
 	}
 

--- a/internal/registryauth/tls.go
+++ b/internal/registryauth/tls.go
@@ -52,84 +52,83 @@ func (t tlsDispatchTransport) RoundTrip(req *http.Request) (*http.Response, erro
 // unchanged. Returns inner and a no-op closer when no host configures TLS.
 //
 // The returned closer must be called when the transport is no longer needed; it
-// closes any SPIFFE Workload API sources opened for the configured hosts.
+// closes the SPIFFE Workload API source, if one was opened.
 func NewTLSTransport(ctx context.Context, inner http.RoundTripper, hosts []apiv1.RegistryHost) (http.RoundTripper, func() error, error) {
 	if !NeedsTLS(hosts) {
 		return inner, func() error { return nil }, nil
 	}
 
+	// All SPIFFE-using hosts share a single Workload API source: it represents
+	// this workload's own identity and trust bundle, not a per-host one, so one
+	// socket and one rotation goroutine suffice. It is opened lazily, the first
+	// time a host actually needs SPIFFE.
 	byHost := make(map[string]http.RoundTripper)
-	var sources []*workloadapi.X509Source
-	closeSources := func() error {
-		var firstErr error
-		for _, s := range sources {
-			if err := s.Close(); err != nil && firstErr == nil {
-				firstErr = err
-			}
+	var spiffeSrc *workloadapi.X509Source
+	closeSource := func() error {
+		if spiffeSrc != nil {
+			return spiffeSrc.Close()
 		}
-		return firstErr
+		return nil
 	}
 
 	for _, h := range hosts {
 		if h.TLS == nil {
 			continue
 		}
-		tlsCfg, src, err := buildTLSConfig(ctx, h.TLS)
-		if err != nil {
-			_ = closeSources()
-			return nil, nil, fmt.Errorf("host %q: tls: %w", h.Host, err)
+		if spiffeSrc == nil && tlsNeedsSPIFFE(h.TLS) {
+			s, err := workloadapi.NewX509Source(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("host %q: tls: spiffe: create X.509 source: %w", h.Host, err)
+			}
+			spiffeSrc = s
 		}
-		if src != nil {
-			sources = append(sources, src)
+		tlsCfg, err := buildTLSConfig(h.TLS, spiffeSrc)
+		if err != nil {
+			_ = closeSource()
+			return nil, nil, fmt.Errorf("host %q: tls: %w", h.Host, err)
 		}
 		rt := http.DefaultTransport.(*http.Transport).Clone()
 		rt.TLSClientConfig = tlsCfg
 		byHost[h.Host] = rt
 	}
 
-	return tlsDispatchTransport{byHost: byHost, inner: inner}, closeSources, nil
+	return tlsDispatchTransport{byHost: byHost, inner: inner}, closeSource, nil
+}
+
+// tlsNeedsSPIFFE reports whether either half of the TLS config uses SPIFFE and so
+// requires a Workload API source.
+func tlsNeedsSPIFFE(t *apiv1.TLS) bool {
+	clientSPIFFE := t.ClientAuth != nil && t.ClientAuth.Provider == apiv1.TLSClientProviderX509SVID
+	serverSPIFFE := t.ServerAuth != nil && t.ServerAuth.SPIFFE != nil
+	return clientSPIFFE || serverSPIFFE
 }
 
 // buildTLSConfig builds a *tls.Config for a host from its independent server and
 // client settings, each of which may be SPIFFE or static. When either side uses
-// SPIFFE it opens a single Workload API X509Source, returned for the caller to
-// close (nil when no SPIFFE is involved).
-func buildTLSConfig(ctx context.Context, t *apiv1.TLS) (*tls.Config, *workloadapi.X509Source, error) {
+// SPIFFE it draws on src, the shared Workload API source owned by the caller
+// (which must be non-nil whenever the config uses SPIFFE).
+func buildTLSConfig(t *apiv1.TLS, src *workloadapi.X509Source) (*tls.Config, error) {
 	clientSPIFFE := t.ClientAuth != nil && t.ClientAuth.Provider == apiv1.TLSClientProviderX509SVID
 	serverSPIFFE := t.ServerAuth != nil && t.ServerAuth.SPIFFE != nil
 
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
-	var src *workloadapi.X509Source
-	if clientSPIFFE || serverSPIFFE {
-		s, err := workloadapi.NewX509Source(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("spiffe: create X.509 source: %w", err)
-		}
-		src = s
-	}
-	fail := func(err error) (*tls.Config, *workloadapi.X509Source, error) {
-		if src != nil {
-			_ = src.Close()
-		}
-		return nil, nil, err
-	}
 
 	// Server verification: SPIFFE, a custom CA bundle, or (unset) system roots.
 	switch {
 	case serverSPIFFE:
 		authorizer, err := spiffeAuthorizer(src, t.ServerAuth.SPIFFE)
 		if err != nil {
-			return fail(fmt.Errorf("serverAuth: spiffe: %w", err))
+			return nil, fmt.Errorf("serverAuth: spiffe: %w", err)
 		}
 		tlsconfig.HookTLSClientConfig(cfg, src, authorizer)
 	case t.ServerAuth != nil:
 		pemBytes, err := readPEMSource(t.ServerAuth.FromPath, t.ServerAuth.FromEnv, t.ServerAuth.FromBytes)
 		if err != nil {
-			return fail(fmt.Errorf("serverAuth: %w", err))
+			return nil, fmt.Errorf("serverAuth: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pemBytes) {
-			return fail(fmt.Errorf("serverAuth: no valid certificates in CA bundle"))
+			return nil, fmt.Errorf("serverAuth: no valid certificates in CA bundle")
 		}
 		cfg.RootCAs = pool
 	}
@@ -141,19 +140,19 @@ func buildTLSConfig(ctx context.Context, t *apiv1.TLS) (*tls.Config, *workloadap
 	case t.ClientAuth != nil:
 		certPEM, err := readTLSData(t.ClientAuth.Certificate)
 		if err != nil {
-			return fail(fmt.Errorf("clientAuth: certificate: %w", err))
+			return nil, fmt.Errorf("clientAuth: certificate: %w", err)
 		}
 		keyPEM, err := readPEMSource(t.ClientAuth.Key.FromPath, t.ClientAuth.Key.FromEnv, "")
 		if err != nil {
-			return fail(fmt.Errorf("clientAuth: key: %w", err))
+			return nil, fmt.Errorf("clientAuth: key: %w", err)
 		}
 		cert, err := tls.X509KeyPair(certPEM, keyPEM)
 		if err != nil {
-			return fail(fmt.Errorf("clientAuth: load key pair: %w", err))
+			return nil, fmt.Errorf("clientAuth: load key pair: %w", err)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
 	}
-	return cfg, src, nil
+	return cfg, nil
 }
 
 // spiffeAuthorizer turns the configured authorization rule into a tlsconfig

--- a/internal/registryauth/tls_test.go
+++ b/internal/registryauth/tls_test.go
@@ -172,10 +172,7 @@ func TestNewTLSTransport_MTLSEndToEnd(t *testing.T) {
 // takes and that the TLS dispatch matches on.
 func mustHost(t *testing.T, rawURL string) string {
 	t.Helper()
-	g := NewWithT(t)
-	u, err := url.Parse(rawURL)
-	g.Expect(err).ToNot(HaveOccurred())
-	return u.Host
+	return mustURL(t, rawURL).Host
 }
 
 func mustGet(t *testing.T, rawURL string) *http.Request {


### PR DESCRIPTION
Factor the repeated "exactly one of" counting loop in config validators into a shared countTrue helper, collapsing five copy-paste blocks.

Open a single shared SPIFFE Workload API X509Source across all TLS hosts instead of one per host, so N SPIFFE hosts no longer mean N sockets and N rotation goroutines.

Reuse mustURL in the mustHost test helper.


Assisted-by: Claude Code/claude-opus-4-8