### PR TITLE
Revamp docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,11 +1,23 @@
 # Flux Mirror Config
 
-`flux-mirror` is configured via a YAML file listing the OCI artifacts and Helm charts to mirror.
-Sources can be OCI registries or HTTP/S Helm repositories; destinations are OCI registries.
+The `Config` API defines what `flux-mirror` mirrors and how it authenticates to
+the registries involved. A single config lists the registry **hosts** to
+authenticate, the **OCI artifacts** to copy between OCI registries, and the
+**Helm charts** to pull from HTTP/S Helm repositories and publish to an OCI
+registry.
 
-The config shape is published as a JSON Schema in [`config-v1beta1.json`](config-v1beta1.json).
+Sources can be OCI registries or HTTP/S Helm repositories; destinations are
+always OCI registries.
+
+The config shape is published as a JSON Schema in
+[`config-v1beta1.json`](config-v1beta1.json) and is consumed by
+[`flux-mirror sync`](../guides/sync.md), [`flux-mirror login`](../guides/login.md),
+and [`flux-mirror secret`](../guides/secret.md).
 
 ## Example
+
+The following config mirrors a container image and a Helm chart, and
+authenticates to the destination registry with a per-host credential:
 
 ```yaml
 apiVersion: mirror.fluxcd.io/v1beta1
@@ -36,79 +48,59 @@ hosts:
       fromEnv: 'QUAY_TOKEN'
 ```
 
-## Specification
+In the above example:
 
-| Field        | Type   | Default | Description                                                                                 |
-|--------------|--------|---------|---------------------------------------------------------------------------------------------|
-| `apiVersion` | string |         | Must be `mirror.fluxcd.io/v1beta1`.                                                         |
-| `kind`       | string |         | Must be `Config`.                                                                           |
-| `artifacts`  | list   | `[]`    | OCI artifacts (images, OCI Helm charts, Flux artifacts, etc.). See [Artifacts](#artifacts). |
-| `charts`     | list   | `[]`    | Helm charts from HTTP/S Helm repositories. See [Charts](#charts).                           |
-| `hosts`      | list   | `[]`    | Per-host authentication for OCI registry requests. See [Hosts](#hosts).                     |
+- The image at `docker.io/stefanprodan/podinfo` is mirrored to
+  `quay.io/my-org/podinfo`. The two highest `6.x` tags are selected, their cosign
+  signatures, SBOMs, and attestations are mirrored alongside them, and each tag
+  is verified against the listed GitHub Actions OIDC identity (and required to be
+  at least 48h old) before it is copied.
+- The `podinfo` Helm chart is pulled from the HTTP/S repository at
+  `https://stefanprodan.github.io/podinfo` and published as an OCI Helm chart to
+  `quay.io/my-org/charts/podinfo`. The two highest `6.x` versions are mirrored.
+- Requests to `quay.io` authenticate with the Quay robot token read from the
+  `QUAY_TOKEN` environment variable, presented as a username/password pair
+  because `username` is set.
 
-At least one of `artifacts` or `charts` must be set, except for
-[`flux-mirror login`](../guides/login.md), which reads only the `hosts` section and
-accepts a `hosts`-only config.
+You can run this with:
 
-## Artifacts
+```bash
+flux-mirror sync ./config.yaml
+```
 
-The `artifacts` section mirrors OCI artifacts between OCI registries;
-the manifest and all referenced blobs are copied byte-for-byte, preserving digests.
-Multi-arch images are mirrored faithfully as manifest lists; no platform filtering is performed.
+## Writing a Config spec
 
-This section handles any OCI-addressable artifact: container images, OCI Helm
-charts, Flux OCI artifacts, or anything else stored in an OCI registry.
+A config is a single YAML document with `apiVersion: mirror.fluxcd.io/v1beta1`,
+`kind: Config`, and any of the `artifacts`, `charts`, and `hosts` lists.
 
-### Artifact Fields
+At least one `artifacts` or `charts` entry is required, except for
+[`flux-mirror login`](../guides/login.md) and
+[`flux-mirror secret`](../guides/secret.md), which read only the `hosts` section
+and accept a `hosts`-only config.
 
-| Field              | Type   | Default | Description                                                                                                                                                                    |
-|--------------------|--------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `source`           | string |         | Source OCI reference, without scheme (e.g. `ghcr.io/fluxcd/flux-cli`).                                                                                                         |
-| `destination`      | string |         | Destination OCI reference, without scheme.                                                                                                                                     |
-| `selector`         | object |         | Tag selection policy. See [Selector](#selector).                                                                                                                               |
-| `overwrite`        | bool   | `false` | If true, replace tags whose destination digest differs from source. See [Overwrite](#overwrite-behavior).                                                                      |
-| `includeReferrers` | bool   | `false` | If true, also mirror referrers of each tag (cosign signatures, SBOMs, attestations) via the OCI 1.1 API.                                                                       |
-| `verify`           | object |         | Optional source artifact signature verification. When set, selected tags are verified before any copy job is scheduled. See [Signature verification](#signature-verification). |
+### Artifacts
 
-### Selector
+`.artifacts` is an optional field that lists OCI artifacts to mirror between OCI
+registries. The manifest and every referenced blob are copied byte-for-byte,
+preserving digests; multi-arch images are mirrored faithfully as manifest lists,
+with no platform filtering.
 
-The `selector` block decides which tags to mirror. It runs as a four-step
-pipeline: regex prefilter, semver range filter, sort, then cap.
+An entry handles any OCI-addressable content: container images, OCI Helm charts,
+Flux OCI artifacts, or anything else stored in an OCI registry. To mirror a Helm
+chart that is published to an HTTP/S Helm repository (and not yet in an OCI
+registry), use [`.charts`](#charts) instead.
 
-| Field    | Type   | Default  | Description                                                                                                    |
-|----------|--------|----------|----------------------------------------------------------------------------------------------------------------|
-| `regex`  | object |          | Optional regex prefilter applied before sort or version matching. See [Regex Filter](#regex-filter).           |
-| `semver` | string |          | Optional semver range. Tags whose comparison key is not a valid semver are dropped.                            |
-| `sortBy` | string | `semver` | Sort strategy: `semver`, `alphabetical`, or `numerical`.                                                       |
-| `limit`  | int    | `1`      | Number of tags to mirror, taken from the top of the sorted result (highest first). `0` disables the cap.       |
+Each entry has two required fields:
 
-The pipeline always orders highest first and takes the top N.
+- `.source`, the OCI repository the artifact is pulled from, written without a
+  scheme (e.g. `ghcr.io/fluxcd/flux-cli`).
+- `.destination`, the OCI repository the artifact is pushed to, written without a
+  scheme. Selected tags are mirrored to the same tag at the destination.
 
-#### Sort strategies
-
-- `semver`: tags are parsed as semantic versions and sorted by semver
-  precedence. Tags that don't parse are silently dropped. Use `regex` to
-  control what qualifies.
-- `alphabetical`: tags are sorted lexicographically. Useful for tags shaped
-  like `RELEASE.2024-11-12T08-30-15Z` where lexical order matches chronological.
-- `numerical`: tags are parsed as numbers and sorted numerically. Tags that
-  don't parse are silently dropped. Typically paired with `regex` to extract
-  a numeric portion from a composite tag.
-
-#### Regex filter
-
-Applies a Go regular expression to each tag before sort. A named capture
-group can extract a substring used as the comparison key, so tags with
-prefixes or suffixes can still feed into semver or numerical sort.
-
-| Field     | Type   | Description                                                                                                                                            |
-|-----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pattern` | string | Go regular expression. Tags not matching the pattern are dropped.                                                                                      |
-| `extract` | string | Replacement string referencing named capture groups (e.g. `$version`). The extracted value is used for sort and the `semver` filter, not the raw tag.  |
-
-#### Image with Semver tags
-
-Mirror the `flux-cli` container image, selecting versions in the `2.x` range:
+It also has optional fields documented below: `.selector`
+([Tag selection](#tag-selection)), `.includeReferrers` ([Referrers](#referrers)),
+`.verify` ([Signature verification](#signature-verification)), and `.overwrite`
+([Overwrite and drift behavior](#overwrite-and-drift-behavior)).
 
 ```yaml
 artifacts:
@@ -120,54 +112,80 @@ artifacts:
     includeReferrers: true
 ```
 
-`sortBy` defaults to `semver`. Up to 10 of the highest tags in the range are
-mirrored, along with any cosign signatures, SBOMs, or attestations attached
-via the referrers API.
+#### Tag selection
 
-#### Image with CI build tags
+`.artifacts[].selector` is a required field that decides which tags of the
+source repository are mirrored. It runs as a four-step pipeline — a regex
+prefilter, a semver range filter, a sort, then a limit — always ordering highest
+first and keeping the top N. The field offers the following subfields:
 
-Some images use build tags of the form `<branch>-<short-sha>-<timestamp>`
-(e.g. `main-a1b2c3d-1731420000`). To select by the timestamp portion,
-extract it with `regex` and sort numerically:
+- `.regex`, an optional [Go regular expression](https://pkg.go.dev/regexp/syntax)
+  prefilter applied to every tag before the sort and semver steps. It has a
+  required `.pattern` (tags that do not match are dropped) and an optional
+  `.extract` replacement string referencing named capture groups (e.g.
+  `$version`). When `.extract` is set, the extracted value — not the raw tag — is
+  used as the comparison key, so tags with prefixes or suffixes can still feed
+  into a semver or numerical sort.
+- `.semver`, an optional [semver range](https://github.com/Masterminds/semver#checking-version-constraints)
+  (e.g. `>=2.7.0 <3.0.0` or `6.x`). Tags whose comparison key is not a valid
+  semantic version are dropped.
+- `.sortBy`, the sort strategy. The default is `semver`.
+- `.limit`, how many tags to mirror, taken from the top of the sorted result. It
+  defaults to `1`; `0` disables the cap and mirrors every matching tag.
+
+The supported sort strategies are:
+
+- `semver` parses each tag as a semantic version and orders by semver
+  precedence. Tags that do not parse are silently dropped; use `.regex` to
+  control what qualifies.
+- `alphabetical` orders tags lexicographically. This suits tags shaped like
+  `RELEASE.2024-11-12T08-30-15Z`, where lexical order matches chronological
+  order.
+- `numerical` parses each tag as a number and orders numerically. Tags that do
+  not parse are silently dropped; this is typically paired with `.regex` to
+  extract a numeric portion from a composite tag.
+
+For example, to select the highest five tags by an embedded timestamp:
 
 ```yaml
-artifacts:
-  - source: ghcr.io/example/nightly-build
-    destination: quay.io/example/nightly-build
-    selector:
-      regex:
-        pattern: '^.+-[0-9a-f]+-(?P<ts>\d+)$'
-        extract: '$ts'
-      sortBy: numerical
-      limit: 5
+selector:
+  regex:
+    pattern: '^.+-[0-9a-f]+-(?P<ts>\d+)$'
+    extract: '$ts'
+  sortBy: numerical
+  limit: 5
 ```
 
-The regex matches tags like `main-a1b2c3d-1731420000` and uses `1731420000`
-as the sort key. The 5 most recent builds by timestamp are mirrored; tags
-that don't match the pattern are dropped.
+#### Referrers
 
-### Signature verification
+`.artifacts[].includeReferrers` is an optional field that, when `true`, also
+mirrors the referrers of each selected tag — cosign signatures, SBOMs, and
+attestations attached via the [OCI 1.1 referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
+It defaults to `false`.
 
-Set `verify.provider: cosign` to verify selected source tags before they are
-mirrored. Verification uses Cosign v3 bundles attached to the source
-artifact as OCI referrers. If any selected tag has no matching valid signature,
-planning fails for that artifact entry and no copy job is scheduled for it.
+#### Signature verification
 
-| Field               | Type     | Description                                                                                                 |
-|---------------------|----------|-------------------------------------------------------------------------------------------------------------|
-| `provider`          | string   | Must be `cosign`.                                                                                           |
-| `minAge`            | duration | Optional minimum age since the verified Rekor integrated timestamp. Tags with newer signatures are skipped. |
-| `matchOIDCIdentity` | list     | One or more OIDC identity matchers accepted for the signing certificate.                                    |
-| `issuer`            | string   | OIDC issuer URL, e.g. `https://token.actions.githubusercontent.com`.                                        |
-| `subject`           | string   | Go regexp matched against the signing certificate subject alternative name.                                 |
+`.artifacts[].verify` is an optional field that verifies the source artifact's
+signature before any tag is copied. Every selected tag is verified at plan time;
+if a selected tag has no matching valid signature, planning fails for that entry
+and no copy job is scheduled. The field offers three subfields:
 
-Multiple `matchOIDCIdentity` entries are treated as alternatives; a signature
-is accepted when any identity matches.
-
-When `minAge` is set, the signature must contain a verified transparency-log
-integrated timestamp old enough to satisfy the duration. Tags with valid but
-too-recent signatures are reported as `skipped` and are not copied; signatures
-without an enforceable verified integrated timestamp fail verification.
+- `.provider`, the verification provider. It must be `cosign`. Verification uses
+  [Cosign keyless bundles](https://docs.sigstore.dev) attached to the source
+  artifact as OCI referrers, so the signing side must publish them as referrers.
+- `.matchOIDCIdentity`, a list of accepted Fulcio certificate identities. Each
+  entry provides an `.issuer` (the OIDC issuer URL, e.g.
+  `https://token.actions.githubusercontent.com`) and a `.subject` (a Go regular
+  expression matched against the certificate subject alternative name). The
+  entries are evaluated in an OR fashion: a signature is accepted when any one
+  identity matches.
+- `.minAge`, an optional [duration](https://pkg.go.dev/time#ParseDuration) that
+  requires a signature to be at least this old, measured from its verified
+  transparency-log (Rekor) integrated timestamp. Tags whose signatures are valid
+  but too recent are reported as `skipped` (reason `signature-too-new`) and not
+  copied; signatures without an enforceable verified integrated timestamp fail
+  verification. Use this to let signatures settle in the transparency log before
+  mirroring.
 
 ```yaml
 artifacts:
@@ -179,62 +197,51 @@ artifacts:
     includeReferrers: true
     verify:
       provider: cosign
-      minAge: 168h # 7 days old
+      minAge: 168h # 7 days
       matchOIDCIdentity:
         - issuer: https://token.actions.githubusercontent.com
           subject: ^https://github\.com/stefanprodan/.*$
 ```
 
-## Charts
+### Charts
 
-The `charts` section mirrors Helm charts from HTTP/S Helm repositories to an OCI
-destination. For each selected version, the chart `.tgz` is downloaded from the
-source and re-published to the destination as a Helm OCI artifact (config blob
-with the chart metadata, layer with the tarball bytes).
+`.charts` is an optional field that lists Helm charts to mirror from an HTTP/S
+Helm repository to an OCI destination. For each selected version, the chart
+`.tgz` is downloaded from the source and re-published to the destination as a
+Helm OCI artifact (a config blob with the chart metadata and a layer with the
+tarball bytes). Charts use the same outcomes and overwrite/dry-run semantics as
+artifacts; drift is detected by comparing the source tarball's content digest
+against the destination chart-layer digest, so re-runs against an unchanged
+source are idempotent.
 
-To mirror a Helm chart that already lives in an OCI registry, use the
-[`artifacts`](#artifacts) section instead — an OCI Helm chart is mirrored as a
-plain OCI artifact (an OCI-to-OCI copy), not through this section.
+Each entry offers the following subfields:
 
-Charts use the same outcomes (`copied`, `skipped`, `overwritten`, `drifted`)
-and the same `--overwrite` / `--dry-run` semantics as artifacts. Drift is
-detected by comparing the source tarball's content digest against the
-destination chart-layer digest, so re-runs against an unchanged source are
-idempotent.
+- `.name`, the chart name within the source repository. Required.
+- `.source`, the HTTP/S Helm repository URL the chart is pulled from. Required;
+  the scheme must be `http` or `https`, and the repository must serve a classic
+  `index.yaml` plus chart tarballs.
+- `.destination`, the OCI base URL the chart is published to. Required; the
+  scheme must be `oci`.
+- `.version`, an optional [semver range](https://github.com/Masterminds/semver#checking-version-constraints)
+  (e.g. `>=2.7.0 <3.0.0`). Versions outside the range are dropped. It defaults to
+  `*` (all versions).
+- `.limit`, how many matching versions to mirror, highest first. It defaults to
+  `1`; `0` disables the cap.
+- `.overwrite`, see [Overwrite and drift behavior](#overwrite-and-drift-behavior).
 
-### Chart Fields
+Helm repository authentication is **not** configured under `hosts`. It is loaded
+automatically from the ambient Helm repositories config — Helm's default
+`repositories.yaml`, or `$HELM_REPOSITORY_CONFIG` when set — so adding the
+repository with `helm repo add` is enough for `flux-mirror` to pick up matching
+credentials. To mirror a chart that already lives in an OCI registry, list it
+under [`.artifacts`](#artifacts) instead, where it is copied OCI-to-OCI as a
+plain OCI artifact (authenticated through [`hosts`](#hosts)).
 
-| Field         | Type   | Default | Description                                                                                                                     |
-|---------------|--------|---------|---------------------------------------------------------------------------------------------------------------------------------|
-| `name`        | string |         | Chart name within the source repository.                                                                                        |
-| `source`      | string |         | Source Helm repository URL. Scheme must be `http` or `https`. To mirror a chart already in an OCI registry, use [`artifacts`](#artifacts). |
-| `destination` | string |         | Destination OCI base URL. Scheme must be `oci`. The chart `name` is appended automatically.                                     |
-| `version`     | string | `*`     | Semver constraint (e.g. `>=2.7.0 <3.0.0`). Versions outside the range are dropped.                                              |
-| `limit`       | int    | `1`     | Number of versions to mirror, taken from the highest matching versions. `0` disables the cap.                                   |
-| `overwrite`   | bool   | `false` | If true, replace the destination tag when its chart-layer digest differs from the source. See [Overwrite](#overwrite-behavior). |
-
-### Source scheme
-
-The source must be an `http` / `https` classic Helm repository serving
-`index.yaml` plus chart tarballs. Auth is loaded automatically from the ambient
-Helm repositories config (`repositories.yaml`, or `HELM_REPOSITORY_CONFIG` when
-set); no auth fields are needed in the flux-mirror YAML.
-
-A Helm chart that already lives in an OCI registry is mirrored OCI-to-OCI: list
-it under [`artifacts`](#artifacts), where it is copied as a plain OCI artifact
-(authenticated through the [`hosts`](#hosts) section).
-
-### Destination convention
-
-`destination` is the parent path; the chart `name` is appended automatically.
-For `destination: oci://quay.io/example/charts` and `name: nginx`, versions
-land at `quay.io/example/charts/nginx:<version>`.
-
-OCI tags do not accept `+`, so semver build metadata (e.g. `1.2.3+meta`) is
-encoded as `_` in the destination tag (`1.2.3_meta`). Listing and comparison
-treat both forms as the same version.
-
-#### HTTP Helm repository
+The chart `.name` is appended to `.destination` automatically: for `destination:
+oci://quay.io/example/charts` and `name: nginx`, versions land at
+`quay.io/example/charts/nginx:<version>`. Because OCI tags do not accept `+`,
+semver build metadata (e.g. `1.2.3+meta`) is encoded with `_` in the destination
+tag (`1.2.3_meta`); listing and comparison treat both forms as the same version.
 
 ```yaml
 charts:
@@ -245,210 +252,220 @@ charts:
     limit: 5
 ```
 
-The 5 highest `15.x` versions of the `nginx` chart are mirrored to
-`quay.io/example/charts/nginx:<version>`.
+### Hosts
 
-## Hosts
+`.hosts` is an optional field that configures per-host authentication for OCI
+registry requests, covering both source pulls and destination pushes. A host
+listed here takes priority over the ambient Docker config; requests to hosts that
+are not listed fall back to the Docker config and its credential helpers
+(`~/.docker/config.json`, or `$DOCKER_CONFIG` when set).
 
-The optional `hosts` section configures per-host registry authentication. A host
-listed here takes priority over Docker config. Requests to hosts that are not
-listed fall back to that ambient Docker config.
+> **Note:** the `hosts` section does not apply to HTTP/S Helm repositories
+> (`.charts[].source`), which authenticate through the ambient Helm repositories
+> config.
 
-**Note** that the `hosts` section does not apply to Helm HTTP/S repositories,
-which use the ambient Helm repositories config.
-
-Each host configures either a `credential` (a JWT-based token, below) or a
-cloud registry `provider` — the two are mutually exclusive. A `credential` host
-(or a host with neither) may also set [`tls`](#tls) for transport-layer TLS/mTLS;
-`tls` is not allowed with `provider` (a cloud registry is managed and its
-transport is not customized). The host-level [`maxChunkSize`](#host-fields) tunes
-blob uploads independently of auth. At least one of `credential`, `provider`,
-`tls`, or `maxChunkSize` is required.
+Each entry has one required field, `.host`, the registry host (with optional
+port) the entry applies to (e.g. `registry.example.com` or `localhost:5000`),
+unique across `hosts`. Beyond that, an entry configures **either** a
+[`.credential`](#per-host-credential) **or** a
+[`.provider`](#cloud-registry-providers) — the two are mutually exclusive. A
+`credential` host (or a host with neither) may also set a
+[`.tls`](#transport-tls) block; `tls` is not allowed with `provider`, because a
+cloud registry is managed and its transport is not customized.
+[`.maxChunkSize`](#blob-upload-chunking) tunes blob uploads independently of auth.
+At least one of `credential`, `provider`, `tls`, or `maxChunkSize` must be set.
 
 ```yaml
 hosts:
-  # Form 1: a per-host credential (JWT-based).
+  # A per-host credential (HTTP-layer token).
   - host: registry.example.com
     credential:
-      # Exactly one of the following five selects how the credential is obtained.
-      provider: github           # mint a token (github, forgejo, gcp, azure, aws, or jwt-svid)
-      fromEnv: SOME_ENV_VAR      # send a static JWT read from this env var
-      fromPath: /path/to/token   # send a static JWT read from this file
-      jwkPath: /path/to/jwk.json # sign a fresh JWT per request with this key
-      jwkEnv: SOME_JWK_ENV_VAR   # sign a fresh JWT per request with the key in this env var
-
-      # Required for, and allowed only with, jwkPath or jwkEnv.
-      iss: https://example.com/issuer
-      sub: client-id
-
-      # Optional; allowed only with jwkPath, jwkEnv, or provider. Defaults to host.
-      aud: registry.example.com
-
-      # Optional; allowed only with jwkPath or jwkEnv. JWT lifetime; defaults to 60s.
-      exp: 1h
-
-      # Optional. Changes how the credential is presented (see below).
-      username: robot
-
-  # Form 2: a cloud registry provider (ECR/ACR/GAR), via ambient workload identity.
+      provider: github
+  # A cloud registry provider, via ambient workload identity.
   - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
-    provider: ecr               # one of ecr, acr, gar
+    provider: ecr
 ```
 
-### Bearer token vs. username/password (`credential.username`)
+#### Per-host credential
 
-`username` controls how the resolved credential is presented to the registry:
+`.hosts[].credential` configures an HTTP-layer registry credential for the host.
+Exactly one **token source** subfield selects how the credential is obtained:
 
-- **Unset (default)** — the credential is a bearer token. `sync` sends it as
-  `Authorization: Bearer` on every request (no auth challenge), and
-  `login`/`secret` write it to the Docker config's `registrytoken` field.
-  This suits registries that validate an OIDC token natively. `registrytoken` is
-  non-standard but understood by go-containerregistry (crane, Flux); it is not
-  understood by `kubelet` image pulls.
-- **Set** — the credential becomes the password of a `username`/`password`
-  pair. `sync` goes through the standard registry auth challenge (like the
-  cloud providers — credentials are exchanged at the token endpoint), and
-  `login`/`secret` write `username`/`password`/`auth`.
+- `.provider`, mints a fresh, per-request credential for the audience using a
+  cloud or CI identity, then caches and refreshes it on demand. One of `github`,
+  `forgejo`, `gcp`, `azure`, `aws`, or `jwt-svid` — see
+  [Token providers](#token-providers) for what each obtains and what the registry
+  must accept.
+- `.fromEnv`, sends the JSON Web Token read from the named environment variable
+  as-is (e.g. a GitLab CI `id_token`). It is read once and errors if the variable
+  is unset or empty.
+- `.fromPath`, sends the token read from the file at the path, with surrounding
+  whitespace trimmed. The file is re-read on every request, so the token can be
+  rotated without restarting (useful for a projected ServiceAccount token).
+- `.jwkPath`, signs a fresh JWT per request with the private JSON Web Key in the
+  file at the path. The key may be a bare JWK or a single-key JWK set
+  (`{"keys":[...]}`), and its `kid` is carried in the JWT header. Generate a key
+  pair with [`flux-mirror keygen`](../guides/keygen.md).
+- `.jwkEnv`, the in-environment counterpart to `.jwkPath`: it reads the private
+  JWK from the named environment variable instead of a file.
 
-> ⚠️ Breaking change: credentials without `username` now default to
-> `registrytoken` in `login`/`secret` output (previously a placeholder
-> `username`/`password`). Set `username` to restore `username`/`password`/`auth`.
+The signed and minted sources take additional claim subfields:
 
-### Registry providers
+- `.iss` and `.sub`, the issuer and subject claims. Both are **required** with
+  `.jwkPath` or `.jwkEnv`, and not allowed with the other sources.
+- `.aud`, the audience claim. Allowed with `.jwkPath`, `.jwkEnv`, or `.provider`,
+  and defaults to the host. The audience pins the credential to a specific
+  registry, so it must match what the registry (or the cloud identity provider)
+  expects.
+- `.exp`, the signed JWT lifetime, as a
+  [duration](https://pkg.go.dev/time#ParseDuration). Allowed only with `.jwkPath`
+  or `.jwkEnv` — the sources whose lifetime `flux-mirror` controls — and defaults
+  to `60s`. A longer-lived token is cached and re-minted at half its lifetime.
+  Every other source's lifetime is fixed by its issuer.
+- `.username`, controls how the resolved credential is transported, and therefore
+  what the registry must accept — see
+  [Bearer token vs. username/password](#bearer-token-vs-usernamepassword).
 
-`provider` authenticates the host using the cloud provider's ambient workload
-identity — the same mechanism the `flux push artifact` family uses — and obtains
-the registry credentials directly (no JWT/`credential` involved). It is mutually
-exclusive with `credential`.
+##### Token providers
 
-| `provider` | Cloud registry    | Identity source                                                      |
-|------------|-------------------|----------------------------------------------------------------------|
-| `ecr`      | Amazon ECR (AWS)  | AWS credential chain (IRSA / EC2 / env / SSO, region from the host). |
-| `acr`      | Azure ACR (Azure) | Default Azure credential chain (managed identity, env, ...).         |
-| `gar`      | Google GAR (GCP)  | Google Application Default Credentials.                              |
+When `.credential.provider` is set, the credential is obtained from the
+provider's ambient identity for the audience (defaulting to the host). This is
+what the registry on the other side has to accept:
 
-### Token sources
+- `github` and `forgejo` request an OIDC ID token from the CI Actions OIDC
+  endpoint (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`).
+  The registry must trust the GitHub/Forgejo Actions issuer and match the token's
+  audience and subject (e.g. `repo:my-org/my-repo:ref:refs/heads/main`). The two
+  mint tokens the same way today but are kept distinct so each platform can
+  diverge.
+- `gcp` obtains a Google ID token for the audience via Application Default
+  Credentials (the GKE/GCE metadata server, a service account key, or workload
+  identity federation). The registry must trust Google's OIDC issuer and the
+  configured audience.
+- `azure` obtains a Microsoft Entra ID access token via the default Azure
+  credential chain (AKS/managed identity, workload identity federation,
+  environment credentials). The audience is requested as the `<aud>/.default`
+  scope, so `.aud` must be the application ID URI (or client ID) of a registered
+  Entra application the registry validates tokens against.
+- `aws` is not an OIDC token. AWS mints no JWT, so `flux-mirror` signs an
+  `sts:GetCallerIdentity` request with the ambient role credentials (IRSA, EC2
+  instance role, environment, ...) and wraps it in a JWT-shaped envelope whose
+  header is `{"alg":"none","typ":"aws-sigv4-getcalleridentity"}`. The audience is
+  carried as a signed `X-Audience` header that pins the target registry, not as
+  an OIDC audience claim. The registry verifies the caller by replaying the
+  signed request to AWS STS and reading the returned account/ARN, so the
+  destination **must** understand this scheme — a generic OIDC registry will not.
+- `jwt-svid` fetches a JWT-SVID for the audience from the SPIFFE Workload API
+  (`SPIFFE_ENDPOINT_SOCKET`) and sends it as the credential. The registry must
+  trust the SPIFFE trust domain's JWT bundle. This is the HTTP-layer counterpart
+  to the transport-layer SPIFFE X.509-SVID mTLS configured under
+  [`.tls`](#transport-tls); the two are independent.
 
-| Source     | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `provider` | Mints a fresh, per-request token for `aud` using the named provider's ambient credentials, cached and refreshed on demand. One of `github`, `forgejo`, `gcp`, `azure`, `aws`, or `jwt-svid` — see [Token providers](#token-providers) for what each uses.                                                                                                                                                                  |
-| `fromEnv`  | Sends the JWT read from the named environment variable as-is (e.g. a GitLab CI `id_token`). Errors at runtime if the variable is unset or empty.                                                                                                                                                                                                                                                                           |
-| `fromPath` | Sends the JWT read from the file at the path, with surrounding whitespace trimmed. The file is re-read on every request.                                                                                                                                                                                                                                                                                                   |
-| `jwkPath`  | Signs a fresh JWT with the private Ed25519/ECDSA key in the JWK file at this path. By default each request gets a new 60-second token; set `exp` to issue longer-lived tokens (then cached and reminted at half-life). The file may be a bare JWK or a JWK set (`{"keys":[...]}`) containing exactly one key. The key id is set in the `kid` header. Generate a key pair with [`flux-mirror keygen`](../guides/keygen.md). |
-| `jwkEnv`   | Like `jwkPath`, but reads the private JWK from the named environment variable instead of a file. Same signing behavior, claims (`iss`/`sub`/`aud`), and `exp` semantics. Errors at runtime if the variable is unset or empty.                                                                                                                                                                                              |
+##### Resolving file paths
 
-Path values (`fromPath`, `jwkPath`, and the `tls` path fields) are resolved relative to the config file's directory.
-A config can only reference files under its own directory tree.
-When the config is read from stdin (`-f -`), the process working directory is used as the confinement root instead.
+`.fromPath`, `.jwkPath`, and the `.tls` path fields are resolved relative to the
+config file's directory, and a config may only reference files under its own
+directory tree. When the config is read from stdin (`-f -`), the process working
+directory is used as the confinement root instead.
 
-### Token providers
+##### Bearer token vs. username/password
 
-When `credential.provider` is set, the token is minted from the provider's ambient
-credentials for the audience (`aud`, defaulting to the host), then cached and
-refreshed on demand. Each provider obtains it differently — consult the linked
-platform docs for setup:
+`.hosts[].credential.username` controls how the resolved credential is
+transported, and therefore what the registry on the other side must accept:
 
-- `github`, `forgejo` — request an OIDC ID token from the CI Actions endpoint
-  (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`).
-- `gcp` — Google Application Default Credentials (GKE/GCE metadata server,
-  service account key, or workload identity federation).
-- `azure` — the default Azure credential chain (AKS/managed identity, workload
-  identity federation, environment credentials), requesting the `<aud>/.default`
-  scope.
-- `aws` — not an OIDC token. It signs an `sts:GetCallerIdentity` request with the
-  ambient role credentials (IMDS, environment, ...) and wraps it in a JWT-shaped
-  envelope; `aud` is carried as a signed `X-Audience` header that pins the target
-  registry. The registry verifies the caller by replaying the signed request to
-  AWS STS, so the destination must understand this scheme — a generic OIDC
-  registry will not. The envelope uses the JOSE header
-  `{"alg":"none","typ":"aws-sigv4-getcalleridentity"}` so the registry routes it
-  away from JWKS validation and derives identity only from the STS response.
-- `jwt-svid` — fetches a JWT-SVID for `aud` from the SPIFFE Workload API
-  (`SPIFFE_ENDPOINT_SOCKET`). This is the HTTP-layer counterpart to the
-  transport-layer SPIFFE X.509-SVID mTLS under [`tls`](#tls).
+- **`username` unset (default)** — the credential is treated as a **bearer
+  token**. `sync` sends it as an HTTP Bearer credential on every request, with no
+  auth challenge, and `login`/`secret` write it to the Docker config's
+  `registrytoken` field. This suits registries that natively validate an OIDC
+  token (or another self-contained bearer credential). `registrytoken` is
+  understood by [go-containerregistry](https://github.com/google/go-containerregistry)
+  (crane, and Flux's `OCIRepository`/`HelmRepository`), but **not** by `kubelet`
+  image pulls. Because credential helpers only store username/secret pairs, a
+  `registrytoken` is always written to the config file, never to a keychain
+  helper.
+- **`username` set** — the credential becomes the **password** of a
+  username/password pair. `sync` goes through the standard registry auth
+  challenge (credentials are exchanged at the token endpoint, like the cloud
+  providers), and `login`/`secret` write `username`/`password`/`auth`. Use this
+  for registries such as Docker Hub, GHCR, and Quay, which expect a
+  username/password login even when the username is a placeholder the registry
+  ignores.
 
-### Host fields
+Choose `username` deliberately: set it when the registry expects a
+username/password login (or the credential will be consumed by `kubelet`), and
+leave it unset when the registry validates a self-contained bearer token.
 
-A `hosts[]` entry. At least one of `credential`, `provider`, `tls`, or
-`maxChunkSize` must be set. `credential` and `provider` are mutually exclusive;
-`tls` composes with `credential` but is not allowed with `provider`.
+#### Cloud registry providers
 
-| Field          | Type   | Default | Description                                                                                                                                                                                                |
-|----------------|--------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `host`         | string |         | Registry host (with optional port) the entry applies to. Required and unique across `hosts`.                                                                                                               |
-| `credential`   | object |         | Per-host JWT-based credential. Mutually exclusive with `provider`. See [Credential fields](#credential-fields).                                                                                            |
-| `provider`     | string |         | Cloud registry provider, one of `ecr`, `acr`, `gar`. Mutually exclusive with `credential`. See [Registry providers](#registry-providers).                                                                  |
-| `tls`          | object |         | Transport-layer TLS/mTLS for this host. Composes with `credential`; not allowed with `provider`. See [TLS](#tls).                                                                                          |
-| `maxChunkSize` | int    | `0`     | Maximum size in KiB for a blob-upload `PATCH` to this host; larger blobs are split into chunked uploads. `0` disables chunking (one monolithic `PATCH` per blob). Useful behind body-size-capping proxies. |
+`.hosts[].provider` authenticates the host with a cloud registry provider's
+ambient workload identity — the same mechanism the `flux push artifact` family
+uses — and obtains the registry's native credentials directly (no
+`credential`/JWT involved). It is mutually exclusive with `credential`. The
+supported values are:
 
-### Credential fields
+- `ecr`, for Amazon ECR. It uses the AWS credential chain (IRSA, EC2 instance
+  role, environment, SSO), reading the region from the host.
+- `acr`, for Azure ACR. It uses the default Azure credential chain (managed
+  identity, workload identity, environment, ...).
+- `gar`, for Google GAR. It uses Google Application Default Credentials.
 
-The `credential` object on a host. It selects exactly one token source
-(`provider`, `fromEnv`, `fromPath`, `jwkPath`, or `jwkEnv`); see [Token sources](#token-sources)
-for what each does.
+The resolved credentials are presented to the registry as a username/password
+pair through the standard registry auth challenge, and written as
+`username`/`password`/`auth` by [`login`](../guides/login.md) and
+[`secret`](../guides/secret.md).
 
-| Field      | Type     | Default | Description                                                                                                                                                                                                                                                                                                     |
-|------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `provider` | string   |         | Token provider, one of `github`, `forgejo`, `gcp`, `azure`, `aws`, `jwt-svid`. Mutually exclusive with `fromEnv`, `fromPath`, `jwkPath`, and `jwkEnv`. See [Token providers](#token-providers).                                                                                                                 |
-| `fromEnv`  | string   |         | Environment variable holding a static JWT. Mutually exclusive with `provider`, `fromPath`, `jwkPath`, and `jwkEnv`.                                                                                                                                                                                             |
-| `fromPath` | string   |         | Path to a file holding a static JWT. Mutually exclusive with `provider`, `fromEnv`, `jwkPath`, and `jwkEnv`.                                                                                                                                                                                                    |
-| `jwkPath`  | string   |         | Path to a private JSON Web Key, as a bare JWK or a single-key JWK set. Mutually exclusive with `provider`, `fromEnv`, `fromPath`, and `jwkEnv`.                                                                                                                                                                 |
-| `jwkEnv`   | string   |         | Environment variable holding a private JSON Web Key (same shapes as `jwkPath`). Mutually exclusive with `provider`, `fromEnv`, `fromPath`, and `jwkPath`.                                                                                                                                                       |
-| `iss`      | string   |         | Token issuer. Required with `jwkPath` or `jwkEnv`; not allowed otherwise.                                                                                                                                                                                                                                       |
-| `sub`      | string   |         | Token subject. Required with `jwkPath` or `jwkEnv`; not allowed otherwise.                                                                                                                                                                                                                                      |
-| `aud`      | string   | `host`  | Token audience. Allowed only with `jwkPath`, `jwkEnv`, or `provider`; defaults to `host`.                                                                                                                                                                                                                       |
-| `exp`      | duration | `60s`   | JWT lifetime (e.g. `1h`). Allowed only with `jwkPath` or `jwkEnv` — the sources whose lifetime flux-mirror controls. Must be positive. Other sources' lifetimes are fixed by their issuer.                                                                                                                      |
-| `username` | string   |         | When unset, the credential is a bearer token (`registrytoken` / `Authorization: Bearer`). When set, the credential is the password of a `username`/`password` pair, using the standard registry auth challenge. See [Bearer token vs. username/password](#bearer-token-vs-usernamepassword-credentialusername). |
+#### Transport TLS
 
-### TLS
+`.hosts[].tls` configures transport-layer TLS for the host's registry requests,
+separately from the HTTP-layer `credential`. It is applied by `sync` (which
+connects to the registry); `login` and `secret` do not open registry connections
+and ignore it. It is not allowed on a `provider` host. The field has two
+independent halves, of which at least one must be set:
 
-`tls` configures the transport-layer TLS for a host's registry requests, separate
-from the HTTP-layer `credential` above — a host may set both. It is not allowed
-on a `provider` host (a cloud registry is managed and its transport is not
-customized). It is
-applied by `sync` (which connects to the registry); the `login` and `secret`
-commands do not open registry connections and ignore it.
+- `.serverAuth`, how the registry's server certificate is verified. Set exactly
+  one of `.fromPath` / `.fromEnv` / `.fromBytes` to supply a custom CA bundle
+  (one or more concatenated PEM certificates), or `.spiffe` to verify the
+  server's X.509-SVID against the SPIFFE trust bundle. When `.serverAuth` is
+  omitted entirely, the system trust pool is used.
+- `.clientAuth`, the client certificate for mTLS. Set exactly one of `.provider:
+  x509-svid` (present a SPIFFE X.509-SVID from the Workload API) or the static
+  `.certificate` + `.key` pair. The `.certificate` is one of
+  `.fromPath`/`.fromEnv`/`.fromBytes`; the `.key` is one of `.fromPath`/`.fromEnv`
+  (a private key cannot be inlined, so there is no `.fromBytes`).
 
-`tls` has two independent halves — `serverAuth` (how the registry's server
-certificate is verified) and `clientAuth` (the client certificate presented for
-mTLS) — and at least one must be set. Each half independently chooses SPIFFE
-or non-SPIFFE, so SPIFFE can authenticate the client while a normal/custom CA
-verifies the server, or vice versa.
-
-- **`serverAuth`** — exactly one of `fromPath`/`fromEnv`/`fromBytes` (a custom CA
-  bundle, possibly multiple concatenated PEM certs) or `spiffe` (verify the
-  server's X.509-SVID against the SPIFFE trust bundle). When `serverAuth` is
-  omitted, the system trust pool is used.
-- **`clientAuth`** — exactly one of `provider: x509-svid` (present a SPIFFE
-  X.509-SVID from the Workload API) or the static `certificate` + `key` pair.
+Each half chooses SPIFFE or non-SPIFFE independently, so SPIFFE can authenticate
+the client while a normal or custom CA verifies the server, or vice versa. Under
+`.serverAuth.spiffe`, set exactly one of `.serverID` (authorize one exact SPIFFE
+ID), `.trustDomain` (authorize any SVID in that trust domain; the value `self`
+means the client's own trust domain, read from its X.509-SVID), or
+`.authorizeAny: true` (accept any SVID the bundle can validate — discouraged).
+With SPIFFE on either side, the client SVID and trust bundle come from the
+ambient Workload API socket (`SPIFFE_ENDPOINT_SOCKET`) and rotate automatically.
 
 ```yaml
 hosts:
-  # Static: custom CA for server verification and a client cert for mTLS.
+  # Custom CA for server verification and a static client cert for mTLS.
   - host: registry.example.com
     tls:
       serverAuth:
-        # Exactly one of fromPath/fromEnv/fromBytes. May hold multiple
-        # concatenated PEM certificates (a CA pool).
         fromPath: ./certs/ca.crt
       clientAuth:
-        certificate:                  # exactly one of fromPath/fromEnv/fromBytes
+        certificate:
           fromPath: ./certs/client.crt
-        key:                          # exactly one of fromPath/fromEnv (no inline; it's a secret)
+        key:
           fromPath: ./certs/client.key
 
-  # Full SPIFFE: X.509-SVID client cert + SPIFFE server verification.
+  # Full SPIFFE: X.509-SVID client cert and SPIFFE server verification.
   - host: spiffe.example.com
     tls:
       clientAuth:
-        provider: x509-svid           # present our X.509-SVID from the Workload API
+        provider: x509-svid
       serverAuth:
         spiffe:
-          # Exactly one of the following authorizes the server's SVID.
-          serverID: spiffe://example.org/registry   # pin one exact SPIFFE ID, or
-          # trustDomain: example.org                 # any SVID in this trust domain
-          # trustDomain: self                        # any SVID in our own trust domain
-          # authorizeAny: true                       # accept any SVID (discouraged)
+          serverID: spiffe://example.org/registry
+          # trustDomain: example.org   # or any SVID in this trust domain
+          # trustDomain: self          # or any SVID in our own trust domain
+          # authorizeAny: true         # or any SVID at all (discouraged)
 
   # Client-only SPIFFE: SPIFFE client cert, server verified by a public/custom CA.
   - host: public.example.com
@@ -458,66 +475,63 @@ hosts:
       # serverAuth omitted → system trust pool verifies the server.
 ```
 
-With SPIFFE on either side, the client SVID and trust bundle come from the ambient
-Workload API socket (`SPIFFE_ENDPOINT_SOCKET`) and rotate automatically.
-`trustDomain: self` uses the client's own trust domain (read from its X.509-SVID),
-so no value is needed in the common case.
+#### Blob upload chunking
 
-| Field                                | Type   | Description                                                                                                                                                                        |
-|--------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `tls.serverAuth`                     | object | Server-cert verification. Exactly one of `fromPath`/`fromEnv`/`fromBytes` (CA bundle, may contain multiple concatenated PEM certs) or `spiffe`. Omit to use the system trust pool. |
-| `tls.serverAuth.spiffe.serverID`     | string | Authorize one exact server SPIFFE ID. Mutually exclusive with the other `spiffe` fields.                                                                                           |
-| `tls.serverAuth.spiffe.trustDomain`  | string | Authorize any server SVID in this trust domain; `self` means the client's own. Mutually exclusive with the other `spiffe` fields.                                                  |
-| `tls.serverAuth.spiffe.authorizeAny` | bool   | Accept any SVID the bundle can validate (discouraged). Mutually exclusive with the other `spiffe` fields.                                                                          |
-| `tls.clientAuth`                     | object | Client certificate for mTLS. Exactly one of `provider: x509-svid` or the `certificate` + `key` pair.                                                                               |
-| `tls.clientAuth.provider`            | string | `x509-svid` to present a SPIFFE X.509-SVID. Mutually exclusive with `certificate`/`key`.                                                                                           |
-| `tls.clientAuth.certificate`         | object | Client certificate chain. One of `fromPath`/`fromEnv`/`fromBytes`. Requires `key`.                                                                                                 |
-| `tls.clientAuth.key`                 | object | Client private key. One of `fromPath`/`fromEnv` (no `fromBytes` — a private key must not be inlined in the config). Requires `certificate`.                                        |
+`.hosts[].maxChunkSize` is the maximum size, in KiB (1024 bytes), of a
+blob-upload `PATCH` request to this host; larger blobs are split into chunked
+uploads. It defaults to `0`, which disables chunking and sends one monolithic
+`PATCH` per blob. Set it for registries or proxies that cap request body sizes.
 
-## Overwrite behavior
+## Working with Config
 
-The Flux Mirror CLI does not overwrite existing destination tags by default. This
-keeps the safe path the default on immutable registries (ECR with `imageTagMutability: IMMUTABLE`,
-GAR with tag immutability, Harbor with retention rules) and avoids redundant writes on mutable ones.
+### Overwrite and drift behavior
 
-When a tag exists at the destination, the source and destination digests are compared:
+`.artifacts[].overwrite` and `.charts[].overwrite` are optional fields that
+control what happens when a tag or version already exists at the destination.
+`flux-mirror` does not overwrite by default, which keeps the safe path the
+default on immutable registries (ECR with `IMMUTABLE` tag mutability, GAR with
+tag immutability, Harbor with retention rules) and avoids redundant writes on
+mutable ones.
 
-- Same digest: skip silently.
-- Different digest, `overwrite: false`: log a warning and skip. The mirror
-  has drifted from source but will not be brought back in sync without
-  explicit consent.
-- Different digest, `overwrite: true`: push the new digest, replacing the
-  destination tag. Fails if the destination registry enforces tag immutability.
+When a tag already exists at the destination, the source and destination digests
+are compared:
+
+- **Same digest** — skipped silently.
+- **Different digest, `overwrite: false`** — a warning is logged and the tag is
+  left alone, reported as `drifted`. The mirror has diverged from source but is
+  not brought back in sync without explicit consent.
+- **Different digest, `overwrite: true`** — the new digest is pushed, replacing
+  the destination tag. This fails if the destination registry enforces tag
+  immutability.
 
 The drift warning is useful even on immutable registries where the divergence
-cannot be resolved automatically; it shows up in the run output and exit
-code, which audit and alerting can hook into.
+cannot be resolved automatically: it surfaces in the run output and the
+[exit code](../guides/sync.md#exit-codes), which audit and alerting can hook
+into. The [`--overwrite`](../guides/sync.md#flags) CLI flag forces `overwrite:
+true` for every entry, overriding per-entry values, for one-off resyncs.
 
-The `--overwrite` CLI flag forces `overwrite: true` for every entry,
-overriding per-entry values. Use it for one-off resyncs without editing
-the config.
+With `includeReferrers: true`, the same rule applies to referrers. Referrers
+missing at the destination are always mirrored (there is nothing to overwrite) —
+the common case when an upstream signature is published after the artifact was
+first mirrored. Referrers that exist with a different digest are skipped
+(default) or replaced (`overwrite: true`).
 
-When combined with `includeReferrers: true`, the same rule applies to
-referrers. Referrers that are missing at the destination are always mirrored
-(there is nothing to overwrite); this is the common case when an upstream
-signature is published after the artifact was first mirrored. Referrers
-that exist with a different digest are skipped (default) or replaced
-(`overwrite: true`).
+### Defaults
 
-## Defaults
+| Field                            | Default  |
+|----------------------------------|----------|
+| `artifacts[].selector.sortBy`    | `semver` |
+| `artifacts[].selector.limit`     | `1`      |
+| `artifacts[].overwrite`          | `false`  |
+| `artifacts[].includeReferrers`   | `false`  |
+| `artifacts[].verify`             | unset    |
+| `charts[].version`               | `*`      |
+| `charts[].limit`                 | `1`      |
+| `charts[].overwrite`             | `false`  |
+| `hosts[].credential.aud`         | `host`   |
+| `hosts[].credential.exp`         | `60s`    |
+| `hosts[].maxChunkSize`           | `0`      |
 
-| Field                          | Default  |
-|--------------------------------|----------|
-| `artifacts[].selector.sortBy`  | `semver` |
-| `artifacts[].selector.limit`   | `1`      |
-| `artifacts[].overwrite`        | `false`  |
-| `artifacts[].includeReferrers` | `false`  |
-| `artifacts[].verify`           | unset    |
-| `artifacts[].verify.minAge`    | unset    |
-| `charts[].version`             | `*`      |
-| `charts[].limit`               | `1`      |
-| `charts[].overwrite`           | `false`  |
-
-`limit: 0` disables the cap and mirrors every matching tag. Use with care:
-unrestricted mirrors can consume significant bandwidth and storage, and may
-trip rate limits on upstream registries.
+A `limit` of `0` disables the cap and mirrors every matching tag or version. Use
+it with care: unrestricted mirrors can consume significant bandwidth and storage
+and may trip rate limits on upstream registries.

--- a/docs/guides/keygen.md
+++ b/docs/guides/keygen.md
@@ -1,40 +1,41 @@
 # Flux Mirror Keygen Command
 
-The `flux-mirror keygen` command generates an EdDSA JSON Web Key pair for
-JWK-based registry auth. The output files plug directly into the
-[`hosts[].credential.jwkPath`](../config/README.md#hosts) config field, which
-`flux-mirror sync` and [`flux-mirror login`](./login.md) use to sign JWTs.
+The `flux-mirror keygen` command generates an EdDSA (Ed25519) JSON Web Key pair
+for [JWK-based registry auth](../config/README.md#per-host-credential). The output
+files plug directly into the
+[`hosts[].credential.jwkPath`](../config/README.md#per-host-credential) config field,
+which [`sync`](./sync.md) and [`login`](./login.md) use to sign JWTs.
+
+## Synopsis
 
 ```
 flux-mirror keygen [flags]
 ```
 
-Generates an EdDSA Ed25519 key pair and writes it to a directory as two JWK
-sets:
+It writes the key pair into a directory as two JWK sets:
 
 | File           | Contents                                                            | Mode   |
 |----------------|---------------------------------------------------------------------|--------|
-| `pubkey.json`  | Public JWK set, share this with the registry or publish it as JWKS. | `0644` |
-| `privkey.json` | Private JWK set, keep it secret.                                    | `0600` |
+| `pubkey.json`  | Public JWK set — share with the registry or publish it as JWKS.     | `0644` |
+| `privkey.json` | Private JWK set — keep it secret.                                   | `0600` |
 
-Both files use the standard JWK set shape `{"keys":[...]}`. The two keys share
-a UUIDv6 `kid` so the signature can be matched against the public set.
+Both files use the standard JWK set shape `{"keys":[...]}`. The two keys share a
+UUIDv6 `kid` so a signature made with the private key can be matched against the
+public set.
 
-### Flags
+## Flags
 
 | Flag               | Default | Description                                                                   |
 |--------------------|---------|-------------------------------------------------------------------------------|
 | `-o, --output-dir` | `.`     | Directory to write `pubkey.json` and `privkey.json` into. Created if missing. |
 
-### Behavior
+## Behavior
 
-- The directory is created with `mkdir -p` if it does not exist.
-- The command refuses to overwrite either file if it already exists. Delete or
-  point at a fresh directory to rotate.
+- The output directory is created (`mkdir -p`) if it does not exist.
+- The command refuses to overwrite either file if it already exists. Delete them
+  or point at a fresh directory to rotate.
 - The private file is written with mode `0600`. If the public write fails, the
-  private file is rolled back so a partial run never leaves a stray key.
-
-### Examples
+  private file is rolled back, so a partial run never leaves a stray key behind.
 
 ```bash
 # Write a key pair into the current directory.
@@ -51,11 +52,52 @@ Output:
 ✔ public key set written to: ./keys/registry/pubkey.json
 ```
 
-### Using the generated keys
+## Example: mint a long-lived login token
 
-- **In a sync config** — point `hosts[].credential.jwkPath` at `privkey.json`.
-  See the [`hosts` section of the config spec](../config/README.md#hosts).
-- **To mint a one-shot JWT** — reference `privkey.json` from a host's
-  `credential.jwkPath` and run [`flux-mirror login`](./login.md).
-- **To grant access** — share `pubkey.json` with the registry operator, or
-  publish it at an HTTPS URL the registry can fetch.
+Unlike `provider`/`fromEnv` credentials — whose lifetime is fixed by an external
+issuer — a `jwkPath` credential is signed locally, so you control its lifetime
+through [`exp`](../config/README.md#per-host-credential). This makes a key pair plus
+`login` a convenient way to mint a single, long-lived bearer token (for example,
+a year-long token for a CI system or an air-gapped agent).
+
+**1. Generate the key pair.**
+
+```bash
+flux-mirror keygen -o ./keys/registry
+```
+
+**2. Reference the private key from a host credential, with a long `exp`.** Set
+`iss`/`sub` to the identity the registry expects, and `exp` to the desired
+lifetime (here ~1 year). With no `username`, the signed JWT is stored as a bearer
+`registrytoken`:
+
+```yaml
+# config.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      jwkPath: ./keys/registry/privkey.json
+      iss: https://my-issuer.example
+      sub: ci-pusher
+      # aud: registry.example.com   # optional, defaults to the host
+      exp: 8760h                     # ~1 year
+```
+
+**3. Log in once to mint and store the token.**
+
+```bash
+flux-mirror login -f ./config.yaml
+```
+
+`login` signs one JWT valid for `exp` and writes it to the Docker config, so
+tools like `flux push artifact` authenticate as that identity until it expires.
+
+**4. Grant access on the registry side.** Share `pubkey.json` with the registry
+operator, or publish it at an HTTPS URL the registry can fetch as JWKS, so the
+registry can verify tokens signed by the matching private key (matched by `kid`).
+
+> Re-run `login` to mint a fresh token before the current one expires. Treat
+> `privkey.json` as a secret: anyone holding it can mint tokens for `sub` until
+> the public key is rotated out.

--- a/docs/guides/login.md
+++ b/docs/guides/login.md
@@ -1,20 +1,38 @@
 # Flux Mirror Login Command
 
 The `flux-mirror login` command resolves the credentials configured under
-[`hosts`](../config/README.md#hosts) and logs in to those registries. It mints the
-*same* credentials `flux-mirror sync` would attach, but once. By default it
-stores them in the Docker config, exactly like `docker login`.
+[`hosts`](../config/README.md#hosts) and stores them in the Docker config, the
+same way `docker login` does. It mints the *same* credentials
+[`flux-mirror sync`](./sync.md) would attach, but once — so any tool that reads
+the Docker config (`docker`, `crane`, `flux push artifact`, `helm`) can then
+authenticate as those identities.
+
+## Synopsis
 
 ```
 flux-mirror login [flags]
 ```
 
-| Flag              | Description                                                                                                                            |
-|-------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `-f`, `--config`  | Path to the flux-mirror config, or `-` for stdin. Defaults to `$FLUX_MIRROR_CONFIG`, else a path derived from the executable location. |
-| `--host`          | Registry host from the config to log in. Repeatable; defaults to all hosts.                                                            |
-| `--docker-config` | Docker config directory, like `docker --config` (default `$DOCKER_CONFIG`, else `~/.docker`).                                          |
-| `--plaintext`     | Store the credential base64-encoded in `config.json`, bypassing any OS keychain helper.                                                |
+## Configuration source
+
+The config path is resolved as: the `--config`/`-f` flag, else
+`$FLUX_MIRROR_CONFIG`, else a path next to the executable (`<executable>.config`).
+`-f -` reads the config from stdin.
+
+`login` reads only the [`hosts`](../config/README.md#hosts) section, so — unlike
+`sync` — it accepts a config with no `artifacts` or `charts`.
+
+## Flags
+
+| Flag              | Default                          | Description                                                                                           |
+|-------------------|----------------------------------|-------------------------------------------------------------------------------------------------------|
+| `-f, --config`    | `$FLUX_MIRROR_CONFIG`, else `<executable>.config` | Path to the flux-mirror config, or `-` for stdin.                                    |
+| `--host`          | all hosts                        | Registry host from the config to log in. Repeatable; defaults to all hosts.                           |
+| `--docker-config` | `$DOCKER_CONFIG`, else `~/.docker` | Docker config directory, like `docker --config`.                                                   |
+| `--plaintext`     | `false`                          | Store the credential base64-encoded in `config.json`, bypassing any OS keychain credential helper.    |
+
+The global `--timeout` flag (default `1m`) bounds credential resolution, which
+for `provider` sources involves a network call to mint the token.
 
 ## Where the credential goes
 
@@ -22,57 +40,165 @@ By default, the credential is written through the Docker credential store,
 exactly like `docker login`:
 
 - If a credential helper is configured (`credsStore`/`credHelpers`) — or, on a
-  fresh config, one is auto-detected for the platform (`docker-credential-*` on
-  `PATH`, e.g. `osxkeychain`, `secretservice`, `pass`, `wincred`) — the secret
-  goes to the OS keychain, not the config file.
+  fresh config, one is auto-detected for the platform (a `docker-credential-*`
+  binary on `PATH`, e.g. `osxkeychain`, `secretservice`, `pass`, `wincred`) — the
+  secret goes to the OS keychain, not the config file.
 - Otherwise, it falls back to a base64-encoded entry in `config.json` (the same
   plaintext fallback `docker login` uses when no helper is available).
 
-The config location follows Docker's own discovery (`--docker-config`, else
-`$DOCKER_CONFIG`, else `~/.docker`).
-
 What gets written depends on the host:
-- A cloud `provider` host, or a `credential` host with `username` set, writes
-  `username`/`password`/`auth`.
-- A `credential` host without `username` writes the bearer `registrytoken`
-  field instead. Because credential helpers only store username/secret pairs, a
-  `registrytoken` always goes to the config file (never a keychain helper).
-  See [`credential.username`](../config/README.md#bearer-token-vs-usernamepassword-credentialusername).
+
+- A cloud [`provider`](../config/README.md#cloud-registry-providers) host, or a
+  [`credential`](../config/README.md#per-host-credential) host with `username` set,
+  writes `username`/`password`/`auth`.
+- A `credential` host without `username` writes the bearer `registrytoken` field
+  instead. Because credential helpers only store username/secret pairs, a
+  `registrytoken` always goes to the config file (never a keychain helper). See
+  [Bearer token vs. username/password](../config/README.md#bearer-token-vs-usernamepassword).
 
 Pass `--plaintext` to force the base64 `config.json` entry and bypass any
-configured or auto-detected credential helper (applies to the username/password
-case; registrytoken is always file-based).
+configured or auto-detected helper (this applies to the username/password case;
+`registrytoken` is always file-based).
 
-## What the credential is
+> **Note:** a TLS-only host (only `tls`, no `credential`/`provider`) has nothing
+> to store and is skipped with a `• skipping <host>` message.
 
-Exactly one source is set per host (enforced by config validation):
+## Examples
 
-| Source     | Credential                                                                                                                                                                  |
-|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `provider` | A freshly minted token for the provider (`github`/`forgejo`/`gcp`/`azure`, the `aws` SigV4 envelope, or a `jwt-svid` from the SPIFFE Workload API). Carries its own expiry. |
-| `fromEnv`  | The value of the named environment variable, as-is.                                                                                                                         |
-| `fromPath` | The contents of the file at the path, with surrounding whitespace trimmed.                                                                                                  |
-| `jwkPath`  | A freshly signed JWT (`iss`/`sub`/`aud` from the config), valid for the credential's `exp` (default 60s). Set `exp` in the config for a longer-lived login token.           |
+### Log in to ECR, ACR, or GAR from GitHub Actions
 
-## Hosts-only config
+Authenticate to the cloud provider with its GitHub Actions OIDC login action,
+then `flux-mirror login` with a [`provider`](../config/README.md#cloud-registry-providers)
+host. `login` mints the registry's native credentials from that ambient identity
+and writes them into the Docker config. Afterwards `flux push artifact` (and any
+other Docker-config-aware tool) authenticates **without** a `--provider` flag,
+because the credentials are already in the config.
 
-`login` reads only the `hosts` section, so — unlike `sync` — it accepts a config
-with no `artifacts` or `charts`:
+A hosts-only config — switch clouds by changing the host and `provider`:
 
 ```yaml
+# hosts.yaml
 apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 hosts:
-  - host: registry.example.com
-    credential:
-      jwkPath: ./keys/registry/privkey.json
-      iss: https://my-issuer.example
-      sub: client-id
-      # aud: registry.example.com   # optional, defaults to host
-      # exp: 1h                      # optional, defaults to 60s
+  - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    provider: ecr
+  # - host: myregistry.azurecr.io
+  #   provider: acr
+  # - host: us-docker.pkg.dev
+  #   provider: gar
 ```
 
-## Examples
+```yaml
+# .github/workflows/push.yaml
+permissions:
+  contents: read
+  id-token: write          # required for GitHub Actions OIDC
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      # --- Amazon ECR ---
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/flux-push
+          aws-region: us-east-1
+      # --- Azure ACR (instead of the AWS step) ---
+      # - uses: azure/login@v2
+      #   with:
+      #     client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      #     tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      #     subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # --- Google GAR (instead of the AWS step) ---
+      # - uses: google-github-actions/auth@v2
+      #   with:
+      #     workload_identity_provider: projects/123/locations/global/workloadIdentityPools/gh/providers/gh
+      #     service_account: flux-push@my-project.iam.gserviceaccount.com
+      - run: flux-mirror login -f ./hosts.yaml
+      # No --provider needed: the credential is already in the Docker config.
+      - run: |
+          flux push artifact \
+            oci://123456789012.dkr.ecr.us-east-1.amazonaws.com/manifests/app:v1.0.0 \
+            --path=./manifests --source="$GITHUB_REPOSITORY" --revision="$GITHUB_SHA"
+```
+
+### Log in to GHCR from GitHub Actions
+
+GHCR authorizes by the token and ignores the username value, but it still expects
+a username/password login — so set `username` to any value (for example a
+`github.*` context key) and pass `GITHUB_TOKEN` as the password via `fromEnv`:
+
+```yaml
+# hosts.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: ghcr.io
+    credential:
+      username: ${GITHUB_REPOSITORY_OWNER}   # ignored by GHCR; any value works
+      fromEnv: GH_TOKEN
+```
+
+```yaml
+# .github/workflows/push.yaml
+permissions:
+  contents: read
+  packages: write
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      - run: envsubst '${GITHUB_REPOSITORY_OWNER}' < hosts.yaml > rendered.yaml
+      - run: flux-mirror login -f ./rendered.yaml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          flux push artifact oci://ghcr.io/$GITHUB_REPOSITORY_OWNER/manifests/app:v1.0.0 \
+            --path=./manifests --source="$GITHUB_REPOSITORY" --revision="$GITHUB_SHA"
+```
+
+### Log in to Docker Hub from GitHub Actions
+
+Docker Hub uses a standard username/password login. Set `username` to the Docker
+Hub account and pass an access token as the password via `fromEnv`:
+
+```yaml
+# hosts.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: docker.io
+    credential:
+      username: ${DOCKERHUB_USERNAME}
+      fromEnv: DOCKERHUB_TOKEN
+```
+
+```yaml
+# .github/workflows/push.yaml
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      - run: envsubst '${DOCKERHUB_USERNAME}' < hosts.yaml > rendered.yaml
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      - run: flux-mirror login -f ./rendered.yaml
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run: |
+          flux push artifact oci://docker.io/$DOCKERHUB_USERNAME/manifests/app:v1.0.0 \
+            --path=./manifests --source="$GITHUB_REPOSITORY" --revision="$GITHUB_SHA"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+```
+
+### Common invocations
 
 ```bash
 # Log in to every host in the default config.
@@ -93,10 +219,12 @@ flux-mirror login --plaintext
 
 ## Notes
 
+- The credential is short-lived (a freshly minted provider token, a signed JWT,
+  or whatever `fromEnv`/`fromPath` holds). Re-run `login` before it expires; for
+  `provider` sources the registry re-validates each request, so a stored
+  credential stops working once it lapses. To mint a longer-lived login token,
+  use a `jwkPath`/`jwkEnv` credential with a longer `exp` — see
+  [keygen](./keygen.md).
 - For `aws`, the credential is a JWT-shaped envelope wrapping a signed
   `sts:GetCallerIdentity` request, not an OIDC token. The destination registry
-  must understand this scheme — see the [`provider` row](../config/README.md#token-sources).
-- The credential is short-lived. Re-run `login` when it expires; for `provider`
-  sources the registry re-validates on each request, so a stored credential
-  stops working once it lapses.
-```
+  must understand this scheme — see [Token providers](../config/README.md#token-providers).

--- a/docs/guides/secret.md
+++ b/docs/guides/secret.md
@@ -1,62 +1,338 @@
 # Flux Mirror Secret Command
 
+The `flux-mirror secret <name>` command resolves the credentials configured under
+[`hosts`](../config/README.md#hosts) for each selected host and writes them into a
+Kubernetes Secret of type `kubernetes.io/dockerconfigjson` — the same shape
+`kubectl create secret docker-registry` produces. These are the *same*
+credentials [`sync`](./sync.md) and [`login`](./login.md) resolve, so the Secret
+can be referenced as an `imagePullSecret`, or by a Flux
+`OCIRepository`/`HelmRepository` `.spec.secretRef`, to pull from a registry that
+understands the configured identity.
+
+Its main use case is rotating short-lived pull Secrets from a `CronJob`.
+
+## Synopsis
+
 ```
 flux-mirror secret <name> [flags]
 ```
 
-Resolve the credential configured under [`hosts`](../config/README.md#hosts) for each
-selected host and write them into a Kubernetes Secret of type
-`kubernetes.io/dockerconfigjson` — the same shape `kubectl create secret
-docker-registry` produces.
+`<name>` is the name of the Secret to create or replace.
 
-By default the Secret is upserted: if one with the same name already exists it
-is replaced in place. This is the right semantic for the command's main use
-case — rotating short-lived pull Secrets from a `CronJob`. Pass `--create` to
-instead fail if the Secret already exists, matching `kubectl create secret
-docker-registry`.
+By default the Secret is **upserted**: if one with the same name already exists it
+is replaced in place. Pass `--create` to instead fail if the Secret already
+exists, matching `kubectl create secret docker-registry`.
 
-These are the *same* credentials `flux-mirror sync` and `flux-mirror login`
-resolve, so the Secret can be referenced as an `imagePullSecret` (or by Flux's
-`OCIRepository`/`HelmRepository`) to pull from a registry that understands the
-configured identity.
+## Configuration source
 
-| Argument | Description                                |
-|----------|--------------------------------------------|
-| `<name>` | Name of the Secret to create or replace.   |
+The config path is resolved as: the `--config`/`-f` flag, else
+`$FLUX_MIRROR_CONFIG`, else `<executable>.config`. `-f -` reads the config from
+stdin. Like `login`, `secret` reads only the [`hosts`](../config/README.md#hosts)
+section and accepts a `hosts`-only config.
 
 ## Flags
 
-| Flag             | Description                                                                                                                            |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `-f`, `--config` | Path to the flux-mirror config, or `-` for stdin. Defaults to `$FLUX_MIRROR_CONFIG`, else a path derived from the executable location. |
-| `--host`         | Registry host from the config to include. Repeatable; defaults to all hosts.                                                           |
-| `--create`       | Fail if the Secret already exists instead of replacing it (like `kubectl create secret docker-registry`).                              |
+| Flag             | Default     | Description                                                                                  |
+|------------------|-------------|----------------------------------------------------------------------------------------------|
+| `-f, --config`   | `$FLUX_MIRROR_CONFIG`, else `<executable>.config` | Path to the flux-mirror config, or `-` for stdin.      |
+| `--host`         | all hosts   | Registry host from the config to include. Repeatable; defaults to all hosts.                  |
+| `--create`       | `false`     | Fail if the Secret already exists instead of replacing it.                                    |
 
 In addition, the command accepts the standard `kubectl` connection flags and
 their env vars — `--kubeconfig` (`$KUBECONFIG`), `--context`, `--cluster`,
-`-n`/`--namespace`, `--user`, `--server`, `--token`, `--request-timeout`,
-`--as`, `--certificate-authority`, `--insecure-skip-tls-verify`, and so on. The
-namespace defaults to the one from the active kubeconfig context (or the
-in-cluster service-account namespace).
+`-n`/`--namespace`, `--user`, `--server`, `--token`, `--request-timeout`, `--as`,
+`--certificate-authority`, `--insecure-skip-tls-verify`, and so on. The namespace
+defaults to the one from the active kubeconfig context, or the in-cluster
+ServiceAccount namespace when running inside a pod.
+
+The global `--timeout` flag (default `1m`) bounds credential resolution, which
+for `provider` sources involves a network call to mint the token.
 
 ## Behavior
 
-- Works both locally (kubeconfig) and in-cluster (falls back to the
-  in-cluster config and service-account namespace).
-- By default, the Secret is upserted (created, or replaced if it exists). With
+- Works both locally (kubeconfig) and in-cluster (falls back to the in-cluster
+  config and ServiceAccount namespace).
+- By default the Secret is upserted (created, or replaced if it exists). With
   `--create`, an existing Secret of the same name is an error.
-- With no `--host`, every host in `hosts` is included. A `--host` that is
-  not present in the config is an error.
+- With no `--host`, every host in `hosts` is included. A `--host` that is not
+  present in the config is an error.
 - The Secret's `.dockerconfigjson` holds one `auths` entry per host. A cloud
-  `provider` host, and a `credential` host with `username` set, write
-  `username`/`password`/`auth`. A `credential` host without `username` writes
-  the bearer `registrytoken` field (understood by go-containerregistry/Flux, not
-  by `kubelet`). See [`credential.username`](../config/README.md#bearer-token-vs-usernamepassword-credentialusername).
+  [`provider`](../config/README.md#cloud-registry-providers) host, and a
+  [`credential`](../config/README.md#per-host-credential) host with `username` set,
+  write `username`/`password`/`auth` (understood by `kubelet` and Flux). A
+  `credential` host without `username` writes the bearer `registrytoken` field
+  (understood by go-containerregistry and Flux, **not** by `kubelet`). See
+  [Bearer token vs. username/password](../config/README.md#bearer-token-vs-usernamepassword).
+- A TLS-only host (only `tls`, no `credential`/`provider`) has nothing to put in
+  the Secret and is skipped with a `• skipping <host>` message.
 - Credentials are short-lived (provider tokens, freshly signed JWTs). Re-run the
   command to refresh the Secret before they expire; by default it replaces the
   existing one in place.
 
 ## Examples
+
+### Rotate ECR, ACR, or GAR pull credentials from a CronJob
+
+A cloud registry such as ECR, ACR, or GAR issues only short-lived credentials, so
+a `CronJob` regenerates the pull Secret on a schedule using the pod's workload
+identity. A [`provider`](../config/README.md#cloud-registry-providers) host mints the
+registry's native username/password from the ambient cloud identity, and `secret`
+writes it as a `dockerconfigjson` Secret usable as an `imagePullSecret`.
+
+The ServiceAccount carries each provider's workload-identity annotations:
+
+```yaml
+# EKS with IRSA (annotation mandatory; EKS Pod Identity needs none)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/flux-mirror
+---
+# AKS Workload Identity (annotation mandatory; pod also needs the
+# azure.workload.identity/use: "true" label)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: 00000000-0000-0000-0000-000000000000
+---
+# GKE Workload Identity Federation (annotation only when impersonating a GSA)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    iam.gke.io/gcp-service-account: flux-mirror@my-project.iam.gserviceaccount.com
+```
+
+The ServiceAccount also needs RBAC to manage the Secret it writes:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flux-mirror-secret
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-mirror-secret
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: flux-mirror
+    namespace: flux-system
+roleRef:
+  kind: Role
+  name: flux-mirror-secret
+  apiGroup: rbac.authorization.k8s.io
+```
+
+A hosts-only config selecting the cloud registry (switch clouds via the host and
+`provider`), stored in a `ConfigMap`:
+
+```yaml
+# mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    provider: ecr
+  # - host: myregistry.azurecr.io
+  #   provider: acr
+  # - host: us-docker.pkg.dev
+  #   provider: gar
+```
+
+The `CronJob` rotates the Secret in its own namespace:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: flux-mirror-regcreds
+  namespace: flux-system
+spec:
+  schedule: "0 */6 * * *"          # rotate well within the credential lifetime
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            azure.workload.identity/use: "true"   # AKS Workload Identity only
+        spec:
+          serviceAccountName: flux-mirror
+          restartPolicy: OnFailure
+          containers:
+            - name: flux-mirror
+              image: ghcr.io/fluxcd/flux-mirror:latest
+              # In-cluster: kubeconfig and namespace are auto-detected.
+              args: ["secret", "regcreds", "-f", "/config/flux/mirror.yaml"]
+              volumeMounts:
+                - name: config
+                  mountPath: /config/flux
+                  readOnly: true
+          volumes:
+            - name: config
+              configMap:
+                name: flux-mirror-config   # holds mirror.yaml
+```
+
+The resulting `regcreds` Secret holds `username`/`password`/`auth`, so it works
+both as a pod `imagePullSecret` and as a Flux `OCIRepository`/`HelmRepository`
+`.spec.secretRef`.
+
+### Rotate credentials for a registry that accepts ServiceAccount OIDC tokens
+
+When the target registry validates the cluster's ServiceAccount OIDC tokens
+directly, project a ServiceAccount token whose audience is the registry host and
+feed it to a [`credential`](../config/README.md#per-host-credential) host via
+`fromPath`. Setting `username` writes the token as the password of a
+username/password pair (`username`/`password`/`auth`), so the resulting Secret
+works as a pod `imagePullSecret` (which `kubelet` can use) as well as a Flux
+`OCIRepository`/`HelmRepository` `.spec.secretRef`. The username value is
+whatever the registry expects alongside the token — many token-validating
+registries ignore it but require it to be present.
+
+Reuse the ServiceAccount and RBAC from the previous example (here the
+ServiceAccount needs no cloud annotations — the registry trusts the cluster
+issuer directly). The config references the token by a relative path, and because
+[file-path fields are confined to the config's own
+directory](../config/README.md#resolving-file-paths), the config and the token
+are mounted together:
+
+```yaml
+# mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      username: sa-oidc          # value the registry expects; often ignored
+      fromPath: registry-token   # the audience is set by the projected volume
+```
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: flux-mirror-regcreds
+  namespace: flux-system
+spec:
+  schedule: "*/30 * * * *"       # rotate ahead of the token's expirationSeconds
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: flux-mirror
+          restartPolicy: OnFailure
+          containers:
+            - name: flux-mirror
+              image: ghcr.io/fluxcd/flux-mirror:latest
+              args: ["secret", "regcreds", "-f", "/config/flux/mirror.yaml"]
+              volumeMounts:
+                - name: flux
+                  mountPath: /config/flux
+                  readOnly: true
+          volumes:
+            # One projected volume holds both the config and the registry token,
+            # so /config/flux/mirror.yaml can reference ./registry-token.
+            - name: flux
+              projected:
+                sources:
+                  - configMap:
+                      name: flux-mirror-config   # holds mirror.yaml
+                  - serviceAccountToken:
+                      path: registry-token
+                      audience: registry.example.com
+                      expirationSeconds: 3600
+```
+
+### Rotate credentials using a SPIFFE JWT-SVID
+
+When the registry accepts SPIFFE JWT-SVIDs, use the
+[`jwt-svid` credential provider](../config/README.md#token-providers): it fetches
+a JWT-SVID for the audience (the registry host) from the SPIFFE Workload API.
+Setting `username` writes the JWT-SVID as the password of a username/password
+pair, so the resulting Secret works as a pod `imagePullSecret` (which `kubelet`
+can use) as well as a Flux `OCIRepository`/`HelmRepository` `.spec.secretRef`.
+The Workload API is exposed to the pod by the SPIFFE CSI driver, and go-spiffe
+locates it through the `SPIFFE_ENDPOINT_SOCKET` environment variable.
+
+Reuse the ServiceAccount and secret-management RBAC from the first example (no
+cloud annotations are needed; the registry trusts the SPIFFE trust domain).
+
+```yaml
+# mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      provider: jwt-svid
+      username: spiffe           # value the registry expects; often ignored
+      # aud defaults to the host (registry.example.com)
+```
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: flux-mirror-regcreds
+  namespace: flux-system
+spec:
+  schedule: "*/30 * * * *"       # rotate ahead of the JWT-SVID lifetime
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: flux-mirror
+          restartPolicy: OnFailure
+          containers:
+            - name: flux-mirror
+              image: ghcr.io/fluxcd/flux-mirror:latest
+              args: ["secret", "regcreds", "-f", "/config/flux/mirror.yaml"]
+              env:
+                # go-spiffe reads the Workload API socket from this variable.
+                - name: SPIFFE_ENDPOINT_SOCKET
+                  value: unix:///spiffe-workload-api/spire-agent.sock
+              volumeMounts:
+                - name: config
+                  mountPath: /config/flux
+                  readOnly: true
+                - name: spiffe-workload-api
+                  mountPath: /spiffe-workload-api
+                  readOnly: true
+          volumes:
+            - name: config
+              configMap:
+                name: flux-mirror-config   # holds mirror.yaml
+            # The SPIFFE CSI driver exposes the SPIRE Agent Workload API socket.
+            - name: spiffe-workload-api
+              csi:
+                driver: csi.spiffe.io
+                readOnly: true
+```
+
+The resulting Secret holds `username`/`password`/`auth`, so it works as a pod
+`imagePullSecret` as well as a Flux `OCIRepository`/`HelmRepository`
+`.spec.secretRef`.
+
+### Common invocations
 
 ```bash
 # Upsert a Secret for all hosts in the default config, in the current namespace.
@@ -68,7 +344,4 @@ flux-mirror secret regcreds --create
 # Specific hosts, a specific namespace and kubeconfig context.
 flux-mirror secret regcreds -n flux-system --context prod \
   --host registry.example.com --host other.example.com -f ./flux-mirror.yaml
-
-# In-cluster (e.g. from a CronJob): kubeconfig and namespace are auto-detected.
-flux-mirror secret regcreds -f /etc/flux-mirror/config.yaml
 ```

--- a/docs/guides/sync.md
+++ b/docs/guides/sync.md
@@ -1,81 +1,80 @@
 # Flux Mirror Sync Command
 
-The `flux-mirror sync` command mirrors Helm charts and OCI artifacts between registries based on a
-declarative YAML config. The command is idempotent, re-running against the same config produces
-the same destination state, copying only what's missing or drifted.
-
-See the [config specification](../config/README.md) for the YAML schema.
+The `flux-mirror sync` command mirrors Helm charts and OCI artifacts between
+registries based on a declarative [`Config`](../config/README.md). It is
+idempotent: re-running against the same config produces the same destination
+state, copying only what is missing or drifted.
 
 ## Synopsis
 
 ```
-flux-mirror sync CONFIG|- [flags]
+flux-mirror sync [CONFIG|-] [flags]
 ```
 
 ## Configuration source
 
-The config file path is resolved in the following order:
+The config path is resolved in the following order:
 
-1. First positional argument (`-` reads YAML from stdin).
-2. `FLUX_MIRROR_CONFIG` environment variable.
-3. Config file at the executable path, e.g. `~/.fluxcd/plugins/flux-mirror.config.yaml`.
+1. The first positional argument (`-` reads the config from stdin).
+2. The `FLUX_MIRROR_CONFIG` environment variable.
+
+If neither is set, the command errors. Unlike [`login`](./login.md) and
+[`secret`](./secret.md), `sync` has no executable-relative default path.
 
 ```bash
-flux-mirror sync examples/podinfo.yaml
-flux-mirror sync - < examples/podinfo.yaml
-FLUX_MIRROR_CONFIG=examples/podinfo.yaml flux-mirror sync
+flux-mirror sync ./flux-mirror.yaml
+flux-mirror sync - < ./flux-mirror.yaml
+FLUX_MIRROR_CONFIG=./flux-mirror.yaml flux-mirror sync
 ```
 
 ## Authentication
 
-`sync` authenticates OCI registry requests (`artifacts` and `oci://` Helm
-sources) per registry host:
+`sync` authenticates OCI registry requests — `artifacts` source/destination and
+`charts` `oci://` destinations — per registry host:
 
-1. Hosts listed in [`hosts`](../config/README.md#hosts) use their configured auth:
-   - `provider: ecr|acr|gar` obtains registry credentials from the cloud
-     provider's workload identity.
-   - `credential` resolves a per-host secret from GitHub/Forgejo OIDC, GCP,
-     Azure, AWS STS, SPIFFE JWT-SVID, `fromEnv`, `fromPath`, or `jwkPath`. With no
-     `username`, it is sent directly as `Authorization: Bearer`. With `username`,
-     it is used as the password in the standard registry auth challenge,
-     which covers registries like Docker Hub, GHCR, and Quay without a prior `docker login`.
-2. Hosts not listed in `hosts` use the Docker config and credential helpers from
-   `~/.docker/config.json`, or the `DOCKER_CONFIG` env var if set.
+1. Hosts listed under [`hosts`](../config/README.md#hosts) use their configured
+   authentication:
+   - [`provider: ecr|acr|gar`](../config/README.md#cloud-registry-providers) obtains the
+     registry's native credentials from the cloud provider's workload identity.
+   - [`credential`](../config/README.md#per-host-credential) resolves a per-host
+     token from a cloud/CI identity, a JWK signature, or an environment variable
+     or file. With no `username` it is sent as an HTTP Bearer credential; with a
+     `username` it is the password in the standard registry auth challenge.
+2. Hosts not listed under `hosts` use the ambient Docker config and credential
+   helpers (`~/.docker/config.json`, or `$DOCKER_CONFIG` when set).
 
-A non-`provider` host may also set [`tls`](../config/README.md#tls) to configure
-transport-layer TLS for its registry connections: a custom CA, a client
+A non-`provider` host may also set [`tls`](../config/README.md#transport-tls) to
+configure transport-layer TLS for its registry connections: a custom CA, a client
 certificate (mTLS), or SPIFFE X.509-SVID mTLS.
 
-Helm HTTP/S repository auth is separate from OCI auth and always comes from the
-ambient Helm repositories config:
+HTTP/S Helm repository authentication (for `charts` sources) is separate from OCI
+auth and always comes from the ambient Helm repositories config:
 
-- Helm's default `repositories.yaml` path, or the `HELM_REPOSITORY_CONFIG` env var if set.
-- `username` / `password`, `certFile`, `keyFile`, `caFile`, `insecure_skip_tls_verify`, and
-  `pass_credentials_all` are honored.
+- Helm's default `repositories.yaml` path, or `$HELM_REPOSITORY_CONFIG` when set.
+- The `username`/`password`, `certFile`, `keyFile`, `caFile`,
+  `insecure_skip_tls_verify`, and `pass_credentials_all` fields are honored.
 
-Log in or add repositories with `helm repo add` and `flux-mirror` picks up
-matching HTTP/S repository credentials automatically.
+Add repositories with `helm repo add` and `flux-mirror` picks up matching HTTP/S
+repository credentials automatically.
 
 ## Flags
 
-| Flag                            | Default | Description                                                                                                                                        |
-|---------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-o, --output text\|yaml\|json` | `text`  | Output format. `text` is human-friendly; `yaml` and `json` print the structured [sync report](../report/README.md) to stdout.                      |
-| `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel within a single config entry. Entries themselves are processed sequentially.                  |
-| `--retries N`                   | `3`     | Maximum number of retry attempts per job, bounded by `--timeout`.                                                                                  |
-| `--overwrite`                   | `false` | Force `overwrite: true` on every entry, regardless of per-entry config. See [Overwrite Behavior](../config/README.md#overwrite-behavior).          |
-| `--drift-exit-code N`           | `2`     | Exit code to use when drift is detected without failures. Set to `0` for immutable destination registries that should not fail CI on drift.        |
-| `--dry-run`                     | `false` | Run the plan and comparison pipeline without performing any writes. Reported as `would-copy` / `would-overwrite` in the output.                    |
-| `--verbose`                     | `false` | Emit a structured log line per operation (entry started, mirroring tag, tag done, entry summary, sync complete) on stderr. Suppresses the spinner. |
-| `--no-progress`                 | `false` | Disable the live progress spinner. Per-job lines and the Summary still print.                                                                      |
-| `--insecure`                    | `false` | Allow plaintext HTTP and skip TLS verification. Test/dev only.                                                                                     |
-| `--timeout DURATION`            | `5m`    | Per-job total budget covering all retry attempts.                                                                                                  |
+| Flag                            | Default | Description                                                                                                                          |
+|---------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
+| `-o, --output text\|yaml\|json` | `text`  | Output format. `text` is human-friendly; `yaml` and `json` print the structured [sync report](../report/README.md) to stdout.       |
+| `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel per job.                                                                       |
+| `--retries N`                   | `3`     | Maximum number of retry attempts per job, within the `--timeout` budget.                                                            |
+| `--timeout DURATION`            | `5m`    | Per-job total budget covering all retry attempts.                                                                                   |
+| `--overwrite`                   | `false` | Force `overwrite: true` on every entry, regardless of per-entry config. See [Overwrite and drift behavior](../config/README.md#overwrite-and-drift-behavior). |
+| `--drift-exit-code N`           | `2`     | Exit code to use when drift is detected without failures (0–255). Set to `0` for immutable destinations that should not fail CI on drift. |
+| `--dry-run`                     | `false` | Run the plan and comparison pipeline without performing any writes. Reported as `would-copy` / `would-overwrite`.                   |
+| `--verbose`                     | `false` | Log every operation and the involved digests on stderr. Suppresses the spinner.                                                     |
+| `--no-progress`                 | `false` | Disable the live progress spinner. Per-job lines and the summary still print.                                                       |
+| `--insecure`                    | `false` | Allow plaintext HTTP and skip TLS verification. Test/dev only.                                                                      |
 
 ## Output
 
 ### Text mode (default)
-
-Pretty-print mode:
 
 ```
 ✓ ghcr.io/stefanprodan/charts/podinfo:6.10.2 (skipped)
@@ -88,19 +87,16 @@ Summary: 1 copied, 1 skipped, 1 failed in 4.2s.
 
 ### Verbose mode
 
-`--verbose` replaces the pretty output with a full diagnostic log stream on stderr.
-
-Every layer push, blob check (existing vs pushed), manifest digest, fallback-tag update for referrers,
-and registry-side warning is logged. Reach for this when diagnosing TLS, auth, missing-blob, or push-rejection issues.
+`--verbose` replaces the pretty output with a full diagnostic log stream on
+stderr — every layer push, blob check, manifest digest, referrer fallback-tag
+update, and registry-side warning. Reach for it when diagnosing TLS, auth,
+missing-blob, or push-rejection issues.
 
 ```
 2026/05/13 09:00:00 sync started entries=3 concurrency=4 retries=3 timeout=5m0s
 2026/05/13 09:00:00 mirroring tag src=ghcr.io/foo/bar:1.0 dst=localhost:5050/bar:1.0
 2026/05/13 09:00:00 Copying from ghcr.io/foo/bar:1.0 to localhost:5050/bar:1.0
 2026/05/13 09:00:00 pushed blob: sha256:fdf53ef8e04176eedbd42713efb2d002f1741c310627b38f444c6f6d92a598f7
-2026/05/13 09:00:00 existing blob: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-2026/05/13 09:00:00 localhost:5050/bar:1.0: digest: sha256:455d6a04fe43df4a93b40e1f92d65b2a9befaa0348e5a461295d961161ebf475 size: 829
-2026/05/13 09:00:00 updating fallback tag sha256-455d6a04... with new referrer
 2026/05/13 09:00:01 tag done src=ghcr.io/foo/bar:1.0 status=copied elapsed=812ms
 …
 2026/05/13 09:00:04 sync complete entries=3 copied=1 overwritten=0 skipped=1 drifted=0 failed=1 duration=4.213s
@@ -109,13 +105,13 @@ and registry-side warning is logged. Reach for this when diagnosing TLS, auth, m
 ### Structured output
 
 `-o yaml` and `-o json` print a versioned report to stdout: a top-level envelope
-(`apiVersion`, `kind`, `$schema`, `report`) wrapping run metadata (`reporter`, `timestamp`,
-`durationMs`), an aggregate `summary` of per-status tag counts, and `results[]`
-where each entry carries a `status` (`completed`/`failed`) and a `tags[]` array
-of per-tag rows. Every row has a `status` and, when known, a source `digest`;
-skipped rows always carry a `reason`; verified rows carry a `verification` block;
-and, with `includeReferrers: true`, a `referrers[]` array. The envelope is
-documented by the [sync report schema](../report/README.md).
+(`apiVersion`, `kind`, `$schema`, `report`) wrapping run metadata (`reporter`,
+`timestamp`, `durationMs`), an aggregate `summary` of per-status tag counts, and
+`results[]` where each entry carries a `status` (`completed`/`failed`) and a
+`tags[]` array of per-tag rows. Every row has a `status` and, when known, a
+source `digest`; skipped rows carry a `reason`; verified rows carry a
+`verification` block; and, with `includeReferrers: true`, a `referrers[]` array.
+The envelope is documented by the [sync report schema](../report/README.md).
 
 ```bash
 # Status of every tag, per entry
@@ -123,9 +119,6 @@ flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | {tag, stat
 
 # Tags that were copied
 flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | select(.status == "copied") | .tag'
-
-# Verified identities
-flux-mirror sync config.yaml -o json | jq '.report.results[].tags[] | select(.verification) | {tag, identity: .verification.identity}'
 
 # Aggregate counts
 flux-mirror sync config.yaml -o json | jq '.report.summary'
@@ -139,145 +132,507 @@ Each tag row (and each referrer row) lands in exactly one of these statuses:
 |-------------------|-----------------------------------------------------------------------------------------------|
 | `copied`          | Destination did not have the tag; mirrored from source.                                       |
 | `overwritten`     | Destination had a different digest; replaced (only with `overwrite: true`).                   |
-| `skipped`         | Nothing was copied; the row's `reason` says why (see below).                                  |
+| `skipped`         | Nothing was copied; the row's `reason` says why.                                              |
 | `drifted`         | Destination has a different digest, `overwrite: false` — left alone, surfaced in the summary. |
 | `would-copy`      | Dry-run forecast: would have been copied.                                                     |
 | `would-overwrite` | Dry-run forecast: would have been overwritten.                                                |
 | `failed`          | The operation errored; the row's `error` carries the message.                                 |
 
-A `skipped` row always carries a `reason`: `up-to-date` (the destination already
-has the same digest) or `signature-too-new` (a valid signature was deferred by
+A `skipped` row's `reason` is either `up-to-date` (the destination already has
+the same digest) or `signature-too-new` (a valid signature deferred by
 `verify.minAge`).
 
-A failed signature verification (bad/missing signature, OIDC mismatch) is recorded
-as a `failed` tag row carrying the verify error; verification runs at plan time, so
-the first failure stops the entry (tags verified before it still run) while the
-entry itself stays `completed`. A true plan-time failure (e.g. the source registry
-rejected a `ListTags`) surfaces as an entry with `status: "failed"`, an `error`, and
-an empty `tags` array, and is reported live as a `✗ <entry> — plan failed: <err>`
-line. Both kinds count toward `failed`.
+A failed signature verification (bad/missing signature, OIDC mismatch) is
+recorded as a `failed` tag row carrying the verify error; verification runs at
+plan time, so the first failure stops the entry (tags verified before it still
+run) while the entry itself stays `completed`. A true plan-time failure (e.g. the
+source registry rejected a `ListTags`) surfaces as an entry with `status:
+"failed"`, an `error`, and an empty `tags` array, reported live as a `✗ <entry> —
+plan failed: <err>` line. Both kinds count toward `failed`.
 
 ### Referrers
 
 When an entry sets `includeReferrers: true`, each tag row gains a `referrers[]`
 array — one row per mirrored sub-artifact (cosign signature bundle, SBOM,
 attestation), each with its own `digest`, `artifactType`, `status`, and (when
-skipped) `reason`. Referrers are evaluated in `--dry-run` too, reported with
-`would-copy` / `would-overwrite` / `skipped` statuses without writing.
+skipped) `reason`. Referrers are evaluated under `--dry-run` too.
 
 ## Exit codes
 
-| Code | Meaning                                                                                                               |
+| Code | Meaning                                                                                                                |
 |------|-----------------------------------------------------------------------------------------------------------------------|
-| `0`  | Clean run — every tag was copied or skipped as expected, no drift, no failures.                                       |
-| `1`  | At least one tag job failed (network error, push rejected, retries exhausted, plan failure).                          |
+| `0`  | Clean run — every tag was copied or skipped as expected, no drift, no failures.                                        |
+| `1`  | At least one tag job failed (network error, push rejected, retries exhausted, plan failure).                           |
 | `2`  | No failures, but at least one tag drifted with `overwrite: false`. The destination is out of date relative to source. |
 
-Failures take precedence over drift. `--dry-run` does not bump the exit code for `would-copy` / `would-overwrite`,
-but drift detection still produces `2` by default. Use `--drift-exit-code=0` when the destination registry is known to be
+Failures take precedence over drift. `--dry-run` does not bump the exit code for
+`would-copy` / `would-overwrite`, but drift detection still produces `2` by
+default. Use `--drift-exit-code=0` when the destination registry is known to be
 immutable and drift should be logged without failing CI.
 
 ## Examples
 
-### Mirror a Flux artifact with its image
+### Mirror HTTP/S Helm charts into OCI Helm charts
 
-A typical `Kustomization` workload pulls two artifacts: the manifests from an
-`OCIRepository`, and the container images those manifests reference (often
-rewritten via `spec.images` patches). A single config can mirror both so the
-destination registry is self-sufficient.
+Many common Kubernetes ecosystem components are still published only to classic
+HTTP/S Helm repositories and do not offer OCI Helm charts. The
+[`charts`](../config/README.md#charts) section pulls those charts over HTTP/S and
+re-publishes them as OCI Helm charts so a cluster can consume them from a single
+OCI registry.
 
-```yaml
-# config.yaml
-apiVersion: mirror.fluxcd.io/v1beta1
-kind: Config
-artifacts:
-  - source: ghcr.io/stefanprodan/manifests/podinfo
-    destination: localhost:5050/manifests/podinfo
-    selector:
-      regex:
-        pattern: "^latest$"
-      sortBy: alphabetical
-      limit: 1
-    includeReferrers: true
-    verify:
-      provider: cosign
-      minAge: 48h
-      matchOIDCIdentity:
-        - issuer: https://token.actions.githubusercontent.com
-          subject: ^https://github\.com/stefanprodan/.*$
-    overwrite: true
-  - source: ghcr.io/stefanprodan/podinfo
-    destination: localhost:5050/podinfo
-    selector:
-      semver: "*"
-      limit: 1
-    includeReferrers: true
-```
-
-```bash
-flux-mirror sync config.yaml
-```
-
-### Mirror a Helm chart with its image
-
-A typical `HelmRelease` workload pulls two artifacts: the chart from a Helm
-repository, and the container image referenced by the chart's `values.yaml`.
-A single config can mirror both so the destination registry is self-sufficient.
+This config mirrors a few such charts into GitHub Container Registry (GHCR):
 
 ```yaml
-# config.yaml
+# flux-mirror.yaml
 apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 charts:
-  - source: https://kubernetes-sigs.github.io/external-dns/
-    destination: oci://localhost:5050/charts
-    name: external-dns
+  - name: ingress-nginx
+    source: https://kubernetes.github.io/ingress-nginx
+    destination: oci://ghcr.io/my-org/charts
+    version: ">=4.11.0"
+    limit: 3
+  - name: cert-manager
+    source: https://charts.jetstack.io
+    destination: oci://ghcr.io/my-org/charts
     version: ">=1.15.0"
     limit: 3
+  - name: metrics-server
+    source: https://kubernetes-sigs.github.io/metrics-server
+    destination: oci://ghcr.io/my-org/charts
+    version: ">=3.12.0"
+    limit: 3
+  - name: kube-prometheus-stack
+    source: https://prometheus-community.github.io/helm-charts
+    destination: oci://ghcr.io/my-org/charts
+    version: ">=60.0.0"
+    limit: 3
+hosts:
+  # GHCR is the push destination. It expects a username/password login (the
+  # username is any non-empty value; GHCR authorizes by the token), so `username`
+  # is set and GITHUB_TOKEN is the password.
+  - host: ghcr.io
+    credential:
+      username: my-org
+      fromEnv: GH_TOKEN
+```
+
+Each chart lands at `ghcr.io/my-org/charts/<name>:<version>`. Run it from GitHub
+Actions with `packages: write` so the workflow's `GITHUB_TOKEN` can push:
+
+```yaml
+# .github/workflows/mirror-charts.yaml
+name: mirror-charts
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      - run: flux-mirror sync ./flux-mirror.yaml --no-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Mirror OCI Helm charts into OCI Helm charts
+
+A Helm chart that already lives in an OCI registry is mirrored OCI-to-OCI as a
+plain OCI artifact. The [`artifacts`](../config/README.md#artifacts) section is
+the only way to mirror an OCI Helm chart between OCI repositories — the
+[`charts`](../config/README.md#charts) section is exclusively for HTTP/S sources.
+
+```yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
 artifacts:
-  - source: registry.k8s.io/external-dns/external-dns
-    destination: localhost:5050/external-dns
+  - source: ghcr.io/stefanprodan/charts/podinfo
+    destination: ghcr.io/my-org/charts/podinfo
     selector:
-      semver: ">=0.15.0"
-      limit: 3
+      semver: ">=6.0.0"
+      limit: 5
+```
+
+### Mirror images from GHCR into a private registry
+
+This mirrors `ghcr.io/fluxcd` controller images into a private registry from
+GitHub Actions. The destination authenticates with a username and password from
+GitHub Actions secrets. The GHCR source is authenticated with `GITHUB_TOKEN`
+(rather than pulled anonymously) to avoid anonymous pull rate limits — GHCR
+expects a username/password login, so `username` is set there too.
+
+```yaml
+# flux-mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: ghcr.io/fluxcd/source-controller
+    destination: registry.internal.example.com/fluxcd/source-controller
+    selector:
+      semver: ">=1.0.0"
+      limit: 5
     includeReferrers: true
+  - source: ghcr.io/fluxcd/kustomize-controller
+    destination: registry.internal.example.com/fluxcd/kustomize-controller
+    selector:
+      semver: ">=1.0.0"
+      limit: 5
+    includeReferrers: true
+hosts:
+  # Source: authenticate to GHCR to avoid anonymous rate limits.
+  - host: ghcr.io
+    credential:
+      username: my-org
+      fromEnv: GH_TOKEN
+  # Destination: a private registry expecting a username/password login. The
+  # password is read from the environment; the username is substituted into the
+  # config in CI (see the envsubst step below).
+  - host: registry.internal.example.com
+    credential:
+      username: ${REGISTRY_USERNAME}
+      fromEnv: REGISTRY_PASSWORD
 ```
 
-```bash
-flux-mirror sync config.yaml
+> **Note:** `credential.username` is a literal string in the config — it is not
+> an env reference. To source it from a secret, substitute it before running
+> `sync` (e.g. with `envsubst`, as below). Only the password is read at runtime
+> from the environment via `fromEnv`.
+
+```yaml
+# .github/workflows/mirror-images.yaml
+name: mirror-images
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+permissions:
+  contents: read
+  packages: read
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      - name: Substitute the destination username into the config
+        run: envsubst '${REGISTRY_USERNAME}' < flux-mirror.yaml > rendered.yaml
+        env:
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      - run: flux-mirror sync ./rendered.yaml --no-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 ```
 
-The chart lands at `localhost:5050/charts/external-dns:<version>` (the chart
-name is appended to the destination); the image lands at
-`localhost:5050/external-dns:<version>`. Override the image reference in the
-consuming `HelmRelease.spec.values` to point at the mirror.
+### Mirror into ECR, ACR, or GAR from GitHub Actions
 
-### Preview without writing
+To mirror container images, OCI Helm charts, and Flux OCI artifacts into a cloud
+registry, authenticate to the cloud provider with its GitHub Actions OIDC login
+action, then set [`hosts[].provider`](../config/README.md#cloud-registry-providers) on the
+destination host so `flux-mirror` reuses that ambient identity. The source here
+is GHCR, authenticated with `GITHUB_TOKEN`.
 
-```bash
-flux-mirror sync config.yaml --dry-run -o json
+The config is the same for all three clouds except for the destination host and
+`provider`:
+
+```yaml
+# flux-mirror.yaml — Amazon ECR destination
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: ghcr.io/fluxcd/source-controller   # container image
+    destination: 123456789012.dkr.ecr.us-east-1.amazonaws.com/fluxcd/source-controller
+    selector: { semver: ">=1.0.0", limit: 5 }
+    includeReferrers: true
+  - source: ghcr.io/stefanprodan/charts/podinfo # OCI Helm chart
+    destination: 123456789012.dkr.ecr.us-east-1.amazonaws.com/charts/podinfo
+    selector: { semver: ">=6.0.0", limit: 5 }
+  - source: ghcr.io/stefanprodan/manifests/podinfo # Flux OCI artifact
+    destination: 123456789012.dkr.ecr.us-east-1.amazonaws.com/manifests/podinfo
+    selector: { regex: { pattern: "^latest$" }, sortBy: alphabetical }
+hosts:
+  - host: ghcr.io
+    credential:
+      username: my-org
+      fromEnv: GH_TOKEN
+  - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    provider: ecr
 ```
 
-### Force-resync drifted tags
+For ACR or GAR, change only the destination host and `provider`:
 
-```bash
-flux-mirror sync config.yaml --overwrite
+```yaml
+# Azure ACR
+  - host: myregistry.azurecr.io
+    provider: acr
+# Google GAR
+  - host: us-docker.pkg.dev
+    provider: gar
 ```
 
-### CI-friendly invocation
+The workflow differs only in the cloud login step, all using GitHub Actions OIDC
+(no long-lived cloud keys):
 
-```bash
-flux-mirror sync config.yaml --no-progress
+```yaml
+# .github/workflows/mirror-to-ecr.yaml
+name: mirror-to-ecr
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+permissions:
+  contents: read
+  packages: read
+  id-token: write          # required for GitHub Actions OIDC
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: fluxcd/flux-mirror/actions/setup@main
+      # --- Amazon ECR ---
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/flux-mirror
+          aws-region: us-east-1
+      # --- Azure ACR (instead of the AWS step) ---
+      # - uses: azure/login@v2
+      #   with:
+      #     client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      #     tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      #     subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # --- Google GAR (instead of the AWS step) ---
+      # - uses: google-github-actions/auth@v2
+      #   with:
+      #     workload_identity_provider: projects/123/locations/global/workloadIdentityPools/gh/providers/gh
+      #     service_account: flux-mirror@my-project.iam.gserviceaccount.com
+      - run: flux-mirror sync ./flux-mirror.yaml --no-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-For immutable destination registries, keep CI green while still logging drift:
+### Mirror into ECR, ACR, or GAR from a CronJob with workload identity
 
-```bash
-flux-mirror sync config.yaml --no-progress --drift-exit-code=0
+Inside a cluster, a `CronJob` can mirror on a schedule using the pod's workload
+identity. The destination cloud registry is authenticated with
+[`hosts[].provider`](../config/README.md#cloud-registry-providers) (which uses the ambient
+cloud credential chain — IRSA, AKS Workload Identity, or GKE Workload Identity).
+The source registry here accepts the cluster's ServiceAccount OIDC tokens, so it
+is authenticated with a projected ServiceAccount token sent as an HTTP Bearer
+credential (no `username`).
+
+First, the ServiceAccount, annotated for each provider's workload identity. The
+projected token's audience must be the **source** registry host:
+
+```yaml
+# EKS with IRSA (annotation mandatory)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/flux-mirror
+# EKS Pod Identity needs no annotation (the association is created via the EKS
+# API); the same ServiceAccount works.
+---
+# AKS Workload Identity (annotation mandatory; the pod also needs the
+# azure.workload.identity/use: "true" label)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: 00000000-0000-0000-0000-000000000000
+---
+# GKE Workload Identity Federation. With direct KSA-to-IAM bindings no
+# annotation is needed; when impersonating a GCP service account, annotate it:
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    iam.gke.io/gcp-service-account: flux-mirror@my-project.iam.gserviceaccount.com
 ```
 
-### Read config from stdin
+The config authenticates the destination with `provider` and the source with the
+projected token. Because [file-path fields are confined to the config's own
+directory](../config/README.md#resolving-file-paths), the config and the token
+are mounted together (below) so a relative `fromPath` resolves:
+
+```yaml
+# mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: source-registry.example.com/library/app
+    destination: 123456789012.dkr.ecr.us-east-1.amazonaws.com/library/app
+    selector: { semver: ">=1.0.0", limit: 5 }
+hosts:
+  # Source: a registry that validates the cluster's ServiceAccount OIDC token.
+  # No username → the token is sent as an HTTP Bearer credential. Its audience
+  # (the source host) is set by the projected-token volume, not here.
+  - host: source-registry.example.com
+    credential:
+      fromPath: registry-token
+  # Destination: ECR via the pod's IRSA identity (use acr/gar to switch clouds).
+  - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
+    provider: ecr
+```
+
+The `CronJob` runs as the annotated ServiceAccount and projects a token whose
+audience is the source registry, combined with the config in one volume so the
+relative `fromPath` stays within the config directory:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            azure.workload.identity/use: "true"   # AKS Workload Identity only
+        spec:
+          serviceAccountName: flux-mirror
+          restartPolicy: OnFailure
+          containers:
+            - name: flux-mirror
+              image: ghcr.io/fluxcd/flux-mirror:latest
+              args: ["sync", "/config/flux/mirror.yaml", "--no-progress"]
+              volumeMounts:
+                - name: flux
+                  mountPath: /config/flux
+                  readOnly: true
+          volumes:
+            # One projected volume holds both the config and the registry token,
+            # so /config/flux/mirror.yaml can reference ./registry-token.
+            - name: flux
+              projected:
+                sources:
+                  - configMap:
+                      name: flux-mirror-config   # holds mirror.yaml
+                  - serviceAccountToken:
+                      path: registry-token
+                      audience: source-registry.example.com
+                      expirationSeconds: 3600
+```
+
+### Mirror with the AWS credential provider into a SPIFFE mTLS registry
+
+This `CronJob` pulls container images from a registry that authenticates the
+caller's AWS identity, and pushes them to a registry that requires SPIFFE
+X.509-SVID mTLS. The source host uses the
+[`aws` credential provider](../config/README.md#token-providers), which signs an
+`sts:GetCallerIdentity` request the source registry replays to AWS STS, so the
+pod needs AWS credentials via IRSA. The destination host uses
+[`tls`](../config/README.md#transport-tls) with a SPIFFE client certificate and
+SPIFFE server verification, and no HTTP credential — the registry authorizes the
+client by its X.509-SVID. The SPIFFE SVIDs and trust bundle come from the
+Workload API, which the SPIFFE CSI driver exposes to the pod; go-spiffe locates
+the socket through `SPIFFE_ENDPOINT_SOCKET`.
+
+The ServiceAccount is annotated for IRSA so the `aws` provider can sign as the
+mapped AWS role:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/flux-mirror
+```
+
+```yaml
+# mirror.yaml
+apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: source-registry.example.com/library/app
+    destination: registry.example.org/library/app
+    selector: { semver: ">=1.0.0", limit: 5 }
+hosts:
+  # Source: a registry that validates the caller's AWS identity. No username →
+  # the signed sts:GetCallerIdentity envelope is sent as an HTTP Bearer credential.
+  - host: source-registry.example.com
+    credential:
+      provider: aws
+  # Destination: SPIFFE mTLS in both directions, no HTTP credential. Our client
+  # X.509-SVID authenticates us; the server's SVID is verified against our own
+  # trust domain.
+  - host: registry.example.org
+    tls:
+      clientAuth:
+        provider: x509-svid
+      serverAuth:
+        spiffe:
+          trustDomain: self
+```
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: flux-mirror
+  namespace: flux-system
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: flux-mirror
+          restartPolicy: OnFailure
+          containers:
+            - name: flux-mirror
+              image: ghcr.io/fluxcd/flux-mirror:latest
+              args: ["sync", "/config/flux/mirror.yaml", "--no-progress"]
+              env:
+                # go-spiffe reads the Workload API socket from this variable.
+                - name: SPIFFE_ENDPOINT_SOCKET
+                  value: unix:///spiffe-workload-api/spire-agent.sock
+              volumeMounts:
+                - name: config
+                  mountPath: /config/flux
+                  readOnly: true
+                - name: spiffe-workload-api
+                  mountPath: /spiffe-workload-api
+                  readOnly: true
+          volumes:
+            - name: config
+              configMap:
+                name: flux-mirror-config   # holds mirror.yaml
+            # The SPIFFE CSI driver exposes the SPIRE Agent Workload API socket.
+            - name: spiffe-workload-api
+              csi:
+                driver: csi.spiffe.io
+                readOnly: true
+```
+
+### Preview, resync, and CI invocations
 
 ```bash
-cat config.yaml | flux-mirror sync -
+# Preview the plan without writing to the destination.
+flux-mirror sync ./flux-mirror.yaml --dry-run -o yaml
+
+# Force-resync every drifted tag.
+flux-mirror sync ./flux-mirror.yaml --overwrite
+
+# CI-friendly: no spinner. For immutable destinations, keep CI green on drift.
+flux-mirror sync ./flux-mirror.yaml --no-progress --drift-exit-code=0
 ```


### PR DESCRIPTION
Previews:

- [docs/config/README.md](https://github.com/fluxcd/flux-mirror/blob/revamp-docs/docs/config/README.md)
- [docs/guides/sync.md](https://github.com/fluxcd/flux-mirror/blob/revamp-docs/docs/guides/sync.md)
- [docs/guides/login.md](https://github.com/fluxcd/flux-mirror/blob/revamp-docs/docs/guides/login.md)
- [docs/guides/secret.md](https://github.com/fluxcd/flux-mirror/blob/revamp-docs/docs/guides/secret.md)
- [docs/guides/keygen.md](https://github.com/fluxcd/flux-mirror/blob/revamp-docs/docs/guides/keygen.md)

Prompt:

```
first, lets make sure the Config API docs have the same structure, language, content, objectivity and examples
of the Flux CRD API docs across the controllers. pls read the latest API version of all of them, they
live under docs/spec/ on every controller repo. the Config API docs should describe the behavior of every
field in the Config API. users don't need to know about Go code details. when describing behavior, you
can use natural language words, for example, there should not be "stamps `Authorization: Bearer <credential>`"
but rather "sends the credential as an HTTP Bearer". by reading this documentation, users should know which
behavior to look for on the other side of the integration, for example, which authentication feature to configure
in a given cloud provider or what should the container registry expect in a given feature is used in the CLI.

match the Flux CRD docs' section conventions: use natural-language section titles (not the raw
field path as the heading), and don't create a section for every single field - group related
fields as bullet point lists where appropriate.

second, we should improve command docs. their goal should be to also document the command API from an API
perspective like the Config API docs, but for the flags of course. and in addition they should have rich
examples for specific use cases. see next.

* the sync command should have examples for the following use cases:
  * mirror HTTP/S helm charts into OCI helm charts (using the `.charts` Config API field). this example should
  focus on mirroring public HTTP/S helm charts of common Kubernetes ecosystem components that do not provide
  OCI helm charts, search a few good examples and use them in the docs. they should be mirrored into GHCR using
  `fromEnv: GH_TOKEN` from GitHub Actions with `packages: write` permissions.
  * mirror OCI helm charts into OCI helm charts (using the `.artifacts` Config API field). short example just to
  illustrate that `.artifacts` is the only way to mirror OCI helm charts between OCI repositories, no need to wrap
  any workflows around it.
  * mirror container images from GHCR repositores e.g. `ghcr.io/fluxcd` controllers into a private registry from
  GitHub Actions using a secret for the username and one for the password. should use GH_TOKEN for GHCR to illustrate
  avoiding rate limits.
  * mirror container images, OCI helm charts and flux OCI artifacts into ECR, ACR or GAR from GitHub Actions.
  this will require using the respective cloud provider authentication GitHub Actions, for example,
  `aws-actions/configure-aws-credentials` for ECR, `azure/login` for ACR and `google-github-actions/auth` for GAR.
  sync them from GHCR with `fromEnv: GH_TOKEN` to illustrate accessing a private registry with a token and mirroring
  to cloud provider registries with their respective authentication GitHub Actions.
  * CronJobs using workload identity features to authenticate to ECR, ACR or GAR and mirror container images into
  them from a container registry that accepts ServiceAccount OIDC tokens from the EKS, AKS or GKE clusters. this
  should show the ServiceAccount configuration with the correct annotations from each provider (optional for EKS
  Pod Identity and GCP Workload Identity Federation for GKE, mandatory for AKS Workload Identity, IRSA and GCP
  Workload Identity Federation for GKE using a GCP Service Account). should also show the projected ServiceAccount
  token for the OIDC authentication with the source registry using the registry host as the audience.
  * a CronJob mirroring container images from a registry using the `aws` credential provider into a
  registry using mTLS via SPIFFE for both server and client authentication. show how to mount the SPIFFE
  Workload API into the pod (SPIFFE CSI driver) and set the go-spiffe `SPIFFE_ENDPOINT_SOCKET` env var.

* the login command should have examples for the following use cases:
  * login to ECR, ACR and GAR from GitHub Actions using the respective cloud provider authentication GitHub Actions, for example, `aws-actions/configure-aws-credentials` for ECR, `azure/login` for ACR and `google-github-actions/auth` for GAR. this should illustrate how to authenticate to cloud provider registries from GitHub Actions and how to use the credentials in the CLI with `fromEnv` and `fromSecret`; and then using `flux push artifact` without the `--provider` flag.
  * login to GHCR from GitHub Actions using whatever username since GHCR ignores it e.g. the `github.` context key for `<owner>/<repo>` and `fromEnv: GH_TOKEN` for the password; and then using `flux push artifact`.
  * login to Docker Hub from GitHub Actions using username and password from GHA secrets; and then using `flux push artifact`.

* the secret command should have examples for the following use cases:
  * a CronJob rotating credentials for ECR, ACR or GAR using workload identity features to authenticate to the cloud provider and generate short-lived credentials for the registry. this should show the ServiceAccount configuration with the correct annotations from each provider (optional for EKS Pod Identity and GCP Workload Identity Federation for GKE, mandatory for AKS Workload Identity, IRSA and GCP Workload Identity Federation for GKE using a GCP Service Account).
  * a CronJob rotating credentials for a container registry that accepts ServiceAccount OIDC tokens from the EKS, AKS or GKE clusters. this should show the ServiceAccount projected token configuration for the OIDC authentication with the registry using the registry host as the audience.
  * a CronJob rotating credentials for a registry that accepts SPIFFE JWT-SVIDs using the `jwt-svid` credential provider. this should show the SPIFFE CSI driver mounted into the pod and the go-spiffe `SPIFFE_ENDPOINT_SOCKET` env var set.

* the keygen command should have an example where we run:
  1. the keygen command
  2. the login command using `jwkPath` and a long expiration e.g. 1 year

all the GitHub Actions for authenticating to cloud providers should use GHA OIDC.

when using `.hosts[].credential`, the examples should carefully consider if using `.hosts[].credential.username` is
needed or not, taking into consideration how the registry will expect the credentials. the presence of the username
field defines how credentials are transported and exported. for the `secret` command specifically, every example
using `.hosts[].credential` should set `.hosts[].credential.username` so the generated Secret is a username/password
pull Secret that kubelet can consume.

and most importantly: don't rely exclusively on the current flux-mirror docs to know the behavior you are going to
document. consider that the current docs may have mistakes. you need to cross check every behavior, section by section,
with the actual source code.
```
