### PR TITLE
Introduce environment variable substitution

### DIFF
--- a/api/v1beta1/config_types.go
+++ b/api/v1beta1/config_types.go
@@ -80,7 +80,7 @@ const (
 	// defaultLimit is the chart/selector limit applied when unset.
 	defaultLimit = 1
 
-	// defaultJWKExp is the jwkPath/jwkEnv JWT lifetime when exp is unset. It matches
+	// defaultJWKExp is the jwkPath/jwkValue JWT lifetime when exp is unset. It matches
 	// cijwt's per-request signing lifetime, keeping the default behavior of
 	// short-lived, freshly signed tokens.
 	defaultJWKExp = 60 * time.Second
@@ -123,6 +123,11 @@ type RegistryHost struct {
 	// Host is the registry host (and optional port) the auth applies to.
 	Host string `json:"host"`
 
+	// Username presents the host credential as a username/password pair. When
+	// unset, the host credential is used as a bearer token.
+	// +optional
+	Username string `json:"username,omitempty"`
+
 	// Credential configures the HTTP-layer registry credential for the host.
 	// +optional
 	Credential *RegistryCredential `json:"credential,omitempty"`
@@ -149,33 +154,25 @@ type RegistryHost struct {
 }
 
 // RegistryCredential configures a per-host credential. Exactly one of Provider,
-// FromEnv, FromPath, JWKPath, or JWKEnv selects how the credential is obtained:
+// Value, FromPath, JWKPath, or JWKValue selects how the credential is obtained:
 //
 //   - Provider mints a per-request credential for Aud (an OIDC token for the
 //     OIDC providers, or a signed sts:GetCallerIdentity envelope for aws; see
 //     JWTProviderGitHub, JWTProviderForgejo, JWTProviderGCP, JWTProviderAzure,
 //     JWTProviderAWS).
-//   - FromEnv sends a static JWT read as-is from the named environment variable
-//     (e.g. a GitLab CI id_token).
+//   - Value sends a static JWT read as-is from the config. Environment
+//     substitution can fill this from an environment variable.
 //   - FromPath sends a static JWT read from the file at the path, with leading
 //     and trailing whitespace trimmed.
 //   - JWKPath signs a fresh JWT with the private JSON Web Key at the path.
-//   - JWKEnv signs a fresh JWT with the private JSON Web Key read from the named
-//     environment variable. It is the in-environment counterpart to JWKPath.
+//   - JWKValue signs a fresh JWT with the private JSON Web Key read from the config.
 //
-// Iss and Sub are required for, and may only be set with, JWKPath or JWKEnv. Aud
-// is optional and may only be set with JWKPath, JWKEnv, or Provider; it defaults
-// to Host. Exp sets the JWT lifetime and may only be set with JWKPath or JWKEnv,
+// Iss and Sub are required for, and may only be set with, JWKPath or JWKValue. Aud
+// is optional and may only be set with JWKPath, JWKValue, or Provider; it defaults
+// to Host. Exp sets the JWT lifetime and may only be set with JWKPath or JWKValue,
 // the sources whose lifetime flux-mirror controls; it defaults to a short 60s.
 // Every other source's lifetime is fixed by an external issuer or is an opaque
 // static token, so Exp is rejected for them.
-//
-// Username changes how the credential is presented. When unset, the credential
-// is a bearer token: sync stamps it as Authorization: Bearer (no auth
-// challenge), and login/create write it to the Docker config's registrytoken
-// field. When set, the credential becomes the password of a username/password
-// pair: sync goes through the standard registry auth challenge (like the cloud
-// providers), and login/create write username/password/auth.
 type RegistryCredential struct {
 	// Provider mints a per-request credential for the audience, one of
 	// JWTProviderGitHub, JWTProviderForgejo, JWTProviderGCP, JWTProviderAzure,
@@ -184,9 +181,9 @@ type RegistryCredential struct {
 	// +kubebuilder:validation:Enum=github;forgejo;gcp;azure;aws;jwt-svid
 	Provider string `json:"provider,omitempty"`
 
-	// FromEnv sends a static JWT read from the named environment variable.
+	// Value sends a static JWT read from the config.
 	// +optional
-	FromEnv string `json:"fromEnv,omitempty"`
+	Value string `json:"value,omitempty"`
 
 	// FromPath sends a static JWT read from the file at the path.
 	// +optional
@@ -196,16 +193,15 @@ type RegistryCredential struct {
 	// +optional
 	JWKPath string `json:"jwkPath,omitempty"`
 
-	// JWKEnv signs a fresh JWT with the private JSON Web Key read from the named
-	// environment variable.
+	// JWKValue signs a fresh JWT with the private JSON Web Key read from the config.
 	// +optional
-	JWKEnv string `json:"jwkEnv,omitempty"`
+	JWKValue string `json:"jwkValue,omitempty"`
 
-	// Iss is the issuer claim for jwkPath/jwkEnv-signed tokens.
+	// Iss is the issuer claim for jwkPath/jwkValue-signed tokens.
 	// +optional
 	Iss string `json:"iss,omitempty"`
 
-	// Sub is the subject claim for jwkPath/jwkEnv-signed tokens.
+	// Sub is the subject claim for jwkPath/jwkValue-signed tokens.
 	// +optional
 	Sub string `json:"sub,omitempty"`
 
@@ -213,17 +209,13 @@ type RegistryCredential struct {
 	// +optional
 	Aud string `json:"aud,omitempty"`
 
-	// Exp is the jwkPath/jwkEnv JWT lifetime. Defaults to 60s.
+	// Exp is the jwkPath/jwkValue JWT lifetime. Defaults to 60s.
 	// +optional
 	Exp *metav1.Duration `json:"exp,omitempty"`
-
-	// Username presents the credential as a username/password pair.
-	// +optional
-	Username string `json:"username,omitempty"`
 }
 
-// EffectiveExp returns the jwkPath/jwkEnv JWT lifetime with the documented
-// default (60s) applied. Only meaningful for jwkPath/jwkEnv credentials.
+// EffectiveExp returns the jwkPath/jwkValue JWT lifetime with the documented
+// default (60s) applied. Only meaningful for jwkPath/jwkValue credentials.
 func (c RegistryCredential) EffectiveExp() time.Duration {
 	if c.Exp != nil {
 		return c.Exp.Duration
@@ -255,7 +247,7 @@ type TLS struct {
 }
 
 // TLSServerAuth verifies the registry's server certificate. Exactly one of the
-// fields is set: FromPath/FromEnv/FromBytes provide a custom CA bundle (one or
+// fields is set: FromPath/Value provide a custom CA bundle (one or
 // more concatenated PEM certificates), or SPIFFE verifies the server's
 // X.509-SVID against the SPIFFE trust bundle. When ServerAuth is unset entirely,
 // the system trust pool is used.
@@ -264,13 +256,9 @@ type TLSServerAuth struct {
 	// +optional
 	FromPath string `json:"fromPath,omitempty"`
 
-	// FromEnv reads the CA bundle from the named environment variable.
+	// Value inlines the PEM-encoded CA bundle.
 	// +optional
-	FromEnv string `json:"fromEnv,omitempty"`
-
-	// FromBytes inlines the PEM-encoded CA bundle.
-	// +optional
-	FromBytes string `json:"fromBytes,omitempty"`
+	Value string `json:"value,omitempty"`
 
 	// SPIFFE verifies the server's X.509-SVID against the SPIFFE trust bundle.
 	// +optional
@@ -278,32 +266,27 @@ type TLSServerAuth struct {
 }
 
 // TLSData is a single PEM-encoded public value (a client cert chain or a CA
-// bundle) obtained from exactly one of FromPath, FromEnv, or FromBytes.
+// bundle) obtained from exactly one of FromPath or Value.
 type TLSData struct {
 	// FromPath reads the value from the file at the path.
 	// +optional
 	FromPath string `json:"fromPath,omitempty"`
 
-	// FromEnv reads the value from the named environment variable.
+	// Value inlines the PEM-encoded value.
 	// +optional
-	FromEnv string `json:"fromEnv,omitempty"`
-
-	// FromBytes inlines the PEM-encoded value.
-	// +optional
-	FromBytes string `json:"fromBytes,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // TLSKey is a private key source. Unlike the public certificate and CA values it
-// is a secret, so it cannot be inlined in the config (no FromBytes): exactly one
-// of FromPath or FromEnv.
+// is a secret: exactly one of FromPath or Value.
 type TLSKey struct {
 	// FromPath reads the private key from the file at the path.
 	// +optional
 	FromPath string `json:"fromPath,omitempty"`
 
-	// FromEnv reads the private key from the named environment variable.
+	// Value reads the private key from the config.
 	// +optional
-	FromEnv string `json:"fromEnv,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // TLSClientAuth presents a client certificate (mTLS). Either Provider is set

--- a/cmd/flux-mirror/login.go
+++ b/cmd/flux-mirror/login.go
@@ -31,7 +31,7 @@ var loginCmd = &cobra.Command{
 	Long: `Resolve the credentials configured under hosts and store them in
 the Docker config so subsequent registry requests authenticate as those
 identities. These are the same credentials the sync command would attach, minted
-once: an OIDC/cloud token for a provider, the value of fromEnv, the contents of
+once: an OIDC/cloud token for a provider, the inline credential value, the contents of
 fromPath, or a freshly signed JWT for jwkPath. By default every host in the
 config is logged in; restrict with one or more --host flags.
 

--- a/cmd/flux-mirror/login_test.go
+++ b/cmd/flux-mirror/login_test.go
@@ -17,12 +17,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// writeLoginConfig writes a valid config whose single host carries the
-// given credential block (already indented two levels under `credential:`) and
-// returns its path.
-func writeLoginConfig(t *testing.T, credBlock string) string {
+// writeLoginConfig writes a valid config whose single host carries a value credential from MY_LOGIN_TOKEN.
+func writeLoginConfig(t *testing.T) string {
 	t.Helper()
-	return writeLoginConfigIn(t, t.TempDir(), credBlock)
+	return writeLoginConfigIn(t, t.TempDir(), "      value: ${MY_LOGIN_TOKEN}\n")
+}
+
+func writeLoginConfigWithUsername(t *testing.T, username, credBlock string) string {
+	t.Helper()
+	dir := t.TempDir()
+	g := NewWithT(t)
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: ghcr.io/a/b
+    destination: ghcr.io/c/d
+    selector:
+      semver: ">=1.0.0"
+      limit: 1
+hosts:
+  - host: registry.example.com
+    username: ` + username + `
+    credential:
+` + credBlock
+	path := filepath.Join(dir, "config.yaml")
+	g.Expect(os.WriteFile(path, []byte(src), 0o600)).To(Succeed())
+	return path
 }
 
 // writeLoginConfigIn writes the config into dir, so path fields in credBlock
@@ -87,9 +107,16 @@ func parseUnverified(t *testing.T, token string) gojwt.MapClaims {
 // OS keychain helper.
 func loginStore(t *testing.T, configRef, input string) (string, error) {
 	t.Helper()
+	return loginStoreWithArgs(t, configRef, input)
+}
+
+func loginStoreWithArgs(t *testing.T, configRef, input string, extraArgs ...string) (string, error) {
+	t.Helper()
 	const host = "registry.example.com"
 	dir := t.TempDir()
-	args := []string{"login", "--host", host, "--config", configRef, "--docker-config", dir, "--plaintext"}
+	args := make([]string, 0, 8+len(extraArgs))
+	args = append(args, "login", "--host", host, "--config", configRef, "--docker-config", dir, "--plaintext")
+	args = append(args, extraArgs...)
 	if _, err := executeCommandWithInput(args, input); err != nil {
 		return "", err
 	}
@@ -121,14 +148,24 @@ func loginStore(t *testing.T, configRef, input string) (string, error) {
 	return pass, nil
 }
 
-func TestLogin_FromEnv(t *testing.T) {
+func TestLogin_ValueFromEnvSubstitution(t *testing.T) {
 	g := NewWithT(t)
 	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
-	cfg := writeLoginConfig(t, "      fromEnv: MY_LOGIN_TOKEN\n")
+	cfg := writeLoginConfig(t)
 
 	cred, err := loginStore(t, cfg, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cred).To(Equal("static-token-value"))
+}
+
+func TestLogin_NoEnvSubstStoresLiteralValue(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
+	cfg := writeLoginConfig(t)
+
+	cred, err := loginStoreWithArgs(t, cfg, "", "--no-envsubst")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cred).To(Equal("${MY_LOGIN_TOKEN}"))
 }
 
 func TestLogin_FromPath(t *testing.T) {
@@ -191,7 +228,7 @@ kind: Config
 hosts:
   - host: registry.example.com
     credential:
-      fromEnv: MY_LOGIN_TOKEN
+      value: ${MY_LOGIN_TOKEN}
 `
 	cred, err := loginStore(t, "-", src)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -207,7 +244,7 @@ kind: Config
 hosts:
   - host: registry.example.com
     credential:
-      fromEnv: MY_LOGIN_TOKEN
+      value: ${MY_LOGIN_TOKEN}
 `
 	path := filepath.Join(t.TempDir(), "auth-only.yaml")
 	g.Expect(os.WriteFile(path, []byte(src), 0o600)).To(Succeed())
@@ -224,7 +261,7 @@ hosts:
 func TestLogin_StoresRegistryToken(t *testing.T) {
 	g := NewWithT(t)
 	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
-	cfg := writeLoginConfig(t, "      fromEnv: MY_LOGIN_TOKEN\n")
+	cfg := writeLoginConfig(t)
 	dockerDir := t.TempDir()
 
 	out, err := executeCommand([]string{
@@ -256,7 +293,7 @@ func TestLogin_StoresRegistryToken(t *testing.T) {
 func TestLogin_UsernameStoresUserPassword(t *testing.T) {
 	g := NewWithT(t)
 	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
-	cfg := writeLoginConfig(t, "      fromEnv: MY_LOGIN_TOKEN\n      username: robot\n")
+	cfg := writeLoginConfigWithUsername(t, "robot", "      value: ${MY_LOGIN_TOKEN}\n")
 	dockerDir := t.TempDir()
 
 	_, err := executeCommand([]string{
@@ -290,10 +327,10 @@ kind: Config
 hosts:
   - host: a.example.com
     credential:
-      fromEnv: TOKEN_A
+      value: ${TOKEN_A}
   - host: b.example.com
     credential:
-      fromEnv: TOKEN_B
+      value: ${TOKEN_B}
 `
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	g.Expect(os.WriteFile(cfgPath, []byte(src), 0o600)).To(Succeed())
@@ -317,7 +354,8 @@ hosts:
 
 func TestLogin_HostNotFound(t *testing.T) {
 	g := NewWithT(t)
-	cfg := writeLoginConfig(t, "      fromEnv: MY_LOGIN_TOKEN\n")
+	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
+	cfg := writeLoginConfig(t)
 
 	_, err := executeCommand([]string{"login", "--host", "other.example.com", "--config", cfg})
 	g.Expect(err).To(MatchError(ContainSubstring(`host "other.example.com" not found`)))
@@ -341,13 +379,13 @@ artifacts:
 	g.Expect(err).To(MatchError(ContainSubstring("no hosts")))
 }
 
-func TestLogin_FromEnvUnset(t *testing.T) {
+func TestLogin_ValueEnvSubstitutionUnset(t *testing.T) {
 	g := NewWithT(t)
 	t.Setenv("MY_LOGIN_TOKEN", "")
-	cfg := writeLoginConfig(t, "      fromEnv: MY_LOGIN_TOKEN\n")
+	cfg := writeLoginConfig(t)
 
 	_, err := executeCommand([]string{"login", "--config", cfg})
-	g.Expect(err).To(MatchError(ContainSubstring("is not set or empty")))
+	g.Expect(err).To(MatchError(ContainSubstring("exactly one of provider, value, fromPath, jwkPath, or jwkValue")))
 }
 
 func TestLogin_SkipsTLSOnlyHost(t *testing.T) {
@@ -360,7 +398,7 @@ hosts:
   - host: tls.example.com
     tls:
       serverAuth:
-        fromBytes: dummy
+        value: dummy
 `
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	g.Expect(os.WriteFile(path, []byte(src), 0o600)).To(Succeed())

--- a/cmd/flux-mirror/main.go
+++ b/cmd/flux-mirror/main.go
@@ -31,7 +31,8 @@ we adapt to new features and/or find better ways to facilitate what it does.`,
 }
 
 type rootFlags struct {
-	timeout time.Duration
+	timeout    time.Duration
+	noEnvsubst bool
 }
 
 var rootArgs = rootFlags{
@@ -41,6 +42,8 @@ var rootArgs = rootFlags{
 func init() {
 	rootCmd.PersistentFlags().DurationVar(&rootArgs.timeout, "timeout", rootArgs.timeout,
 		"The length of time to wait before giving up on the current operation.")
+	rootCmd.PersistentFlags().BoolVar(&rootArgs.noEnvsubst, "no-envsubst", false,
+		"Disable environment variable substitution in config files.")
 
 	rootCmd.SetOut(os.Stdout)
 }

--- a/cmd/flux-mirror/main_test.go
+++ b/cmd/flux-mirror/main_test.go
@@ -46,7 +46,7 @@ func executeCommandWithInput(args []string, input string) (string, error) {
 }
 
 func resetCmdArgs() {
-	rootArgs.timeout = timeout
+	rootArgs = rootFlags{timeout: timeout}
 	rootCmd.SetIn(os.Stdin)
 
 	versionArgs = versionFlags{output: "text"}

--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -392,12 +392,12 @@ func configBaseDir(path string) (string, error) {
 
 func decodeConfig(cmd *cobra.Command, path string) (*apiv1.Config, error) {
 	if path == "-" {
-		return config.Decode(cmd.InOrStdin())
+		return config.DecodeWithEnvSubst(cmd.InOrStdin(), !rootArgs.noEnvsubst)
 	}
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open config: %w", err)
 	}
 	defer f.Close()
-	return config.Decode(f)
+	return config.DecodeWithEnvSubst(f, !rootArgs.noEnvsubst)
 }

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -81,28 +81,16 @@ func TestJWTTransportOptions(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
-	t.Run("fromEnv reads the named env var", func(t *testing.T) {
+	t.Run("value builds a static token option", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Setenv("MY_CI_TOKEN", "env-token")
 		hosts := []apiv1.RegistryHost{{
 			Host:       "static.example",
-			Credential: &apiv1.RegistryCredential{FromEnv: "MY_CI_TOKEN"},
+			Credential: &apiv1.RegistryCredential{Value: "env-token"},
 		}}
 		opts, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
 		g.Expect(err).ToNot(HaveOccurred())
 		_, err = cijwt.NewTransport(opts...)
 		g.Expect(err).ToNot(HaveOccurred())
-	})
-
-	t.Run("fromEnv with unset env var errors", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Setenv("MY_CI_TOKEN", "")
-		hosts := []apiv1.RegistryHost{{
-			Host:       "static.example",
-			Credential: &apiv1.RegistryCredential{FromEnv: "MY_CI_TOKEN"},
-		}}
-		_, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
-		g.Expect(err).To(MatchError(ContainSubstring("is not set or empty")))
 	})
 
 	t.Run("fromPath builds a token-file transport", func(t *testing.T) {
@@ -208,16 +196,15 @@ func TestJWTTransportOptions(t *testing.T) {
 		g.Expect(err).To(MatchError(ContainSubstring("parse JWK")))
 	})
 
-	t.Run("jwkEnv signs from the named env var", func(t *testing.T) {
+	t.Run("jwkValue signs from the inline value", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Setenv("REGISTRY_JWK", string(mustMarshalJWK(t)))
 		hosts := []apiv1.RegistryHost{{
 			Host: "registry.example",
 			Credential: &apiv1.RegistryCredential{
-				JWKEnv: "REGISTRY_JWK",
-				Iss:    "https://issuer.example",
-				Sub:    "client-id",
-				Aud:    "registry.example",
+				JWKValue: string(mustMarshalJWK(t)),
+				Iss:      "https://issuer.example",
+				Sub:      "client-id",
+				Aud:      "registry.example",
 			},
 		}}
 		opts, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
@@ -226,16 +213,15 @@ func TestJWTTransportOptions(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
-	t.Run("jwkEnv with custom exp signs from the named env var", func(t *testing.T) {
+	t.Run("jwkValue with custom exp signs from the inline value", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Setenv("REGISTRY_JWK", string(mustMarshalJWK(t)))
 		hosts := []apiv1.RegistryHost{{
 			Host: "registry.example",
 			Credential: &apiv1.RegistryCredential{
-				JWKEnv: "REGISTRY_JWK",
-				Iss:    "https://issuer.example",
-				Sub:    "client-id",
-				Exp:    &metav1.Duration{Duration: time.Hour},
+				JWKValue: string(mustMarshalJWK(t)),
+				Iss:      "https://issuer.example",
+				Sub:      "client-id",
+				Exp:      &metav1.Duration{Duration: time.Hour},
 			},
 		}}
 		opts, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
@@ -244,30 +230,14 @@ func TestJWTTransportOptions(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
-	t.Run("jwkEnv with unset env var errors", func(t *testing.T) {
+	t.Run("jwkValue rejects malformed JWK", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Setenv("REGISTRY_JWK", "")
 		hosts := []apiv1.RegistryHost{{
 			Host: "registry.example",
 			Credential: &apiv1.RegistryCredential{
-				JWKEnv: "REGISTRY_JWK",
-				Iss:    "https://issuer.example",
-				Sub:    "client-id",
-			},
-		}}
-		_, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
-		g.Expect(err).To(MatchError(ContainSubstring("is not set or empty")))
-	})
-
-	t.Run("jwkEnv rejects malformed JWK", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Setenv("REGISTRY_JWK", "not json")
-		hosts := []apiv1.RegistryHost{{
-			Host: "registry.example",
-			Credential: &apiv1.RegistryCredential{
-				JWKEnv: "REGISTRY_JWK",
-				Iss:    "https://issuer.example",
-				Sub:    "client-id",
+				JWKValue: "not json",
+				Iss:      "https://issuer.example",
+				Sub:      "client-id",
 			},
 		}}
 		_, err := registryauth.JWTTransportOptions(http.DefaultTransport, hosts)
@@ -278,7 +248,7 @@ func TestJWTTransportOptions(t *testing.T) {
 		g := NewWithT(t)
 		t.Setenv("MY_CI_TOKEN", "env-token")
 		hosts := []apiv1.RegistryHost{
-			{Host: "static.example", Credential: &apiv1.RegistryCredential{FromEnv: "MY_CI_TOKEN"}},
+			{Host: "static.example", Credential: &apiv1.RegistryCredential{Value: "env-token"}},
 			{Host: "mint.example", Credential: &apiv1.RegistryCredential{Provider: apiv1.JWTProviderGitHub}},
 			{Host: "registry.example", Credential: &apiv1.RegistryCredential{
 				JWKPath: writeJWK(t), Iss: "https://issuer.example", Sub: "client-id",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4,7 +4,9 @@ The `Config` API defines what `flux-mirror` mirrors and how it authenticates to
 the registries involved. A single config lists the registry **hosts** to
 authenticate, the **OCI artifacts** to copy between OCI registries, and the
 **Helm charts** to pull from HTTP/S Helm repositories and publish to an OCI
-registry.
+registry. Config files support `${VAR}` environment substitution in field keys
+and values; every referenced environment variable must be set when the config
+is loaded. Use the global `--no-envsubst` flag to disable substitution and parse `${VAR}` strings literally.
 
 Sources can be OCI registries or HTTP/S Helm repositories; destinations are
 always OCI registries.
@@ -43,9 +45,9 @@ charts:
     limit: 2
 hosts:
   - host: quay.io
+    username: 'my-org+robot-user'
     credential:
-      username: 'my-org+robot-user'
-      fromEnv: 'QUAY_TOKEN'
+      value: ${QUAY_TOKEN}
 ```
 
 In the above example:
@@ -296,9 +298,7 @@ Exactly one **token source** subfield selects how the credential is obtained:
   `forgejo`, `gcp`, `azure`, `aws`, or `jwt-svid` — see
   [Token providers](#token-providers) for what each obtains and what the registry
   must accept.
-- `.fromEnv`, sends the JSON Web Token read from the named environment variable
-  as-is (e.g. a GitLab CI `id_token`). It is read once and errors if the variable
-  is unset or empty.
+- `.value`, sends the JSON Web Token configured inline as-is (e.g. a GitLab CI `id_token`). Use `${VAR}` to substitute it from the environment while loading the config.
 - `.fromPath`, sends the token read from the file at the path, with surrounding
   whitespace trimmed. The file is re-read on every request, so the token can be
   rotated without restarting (useful for a projected ServiceAccount token).
@@ -306,23 +306,22 @@ Exactly one **token source** subfield selects how the credential is obtained:
   file at the path. The key may be a bare JWK or a single-key JWK set
   (`{"keys":[...]}`), and its `kid` is carried in the JWT header. Generate a key
   pair with [`flux-mirror keygen`](../guides/keygen.md).
-- `.jwkEnv`, the in-environment counterpart to `.jwkPath`: it reads the private
-  JWK from the named environment variable instead of a file.
+- `.jwkValue`, signs a fresh JWT per request with the private JSON Web Key configured inline. Use `${VAR}` to substitute it from the environment while loading the config.
 
 The signed and minted sources take additional claim subfields:
 
 - `.iss` and `.sub`, the issuer and subject claims. Both are **required** with
-  `.jwkPath` or `.jwkEnv`, and not allowed with the other sources.
-- `.aud`, the audience claim. Allowed with `.jwkPath`, `.jwkEnv`, or `.provider`,
+  `.jwkPath` or `.jwkValue`, and not allowed with the other sources.
+- `.aud`, the audience claim. Allowed with `.jwkPath`, `.jwkValue`, or `.provider`,
   and defaults to the host. The audience pins the credential to a specific
   registry, so it must match what the registry (or the cloud identity provider)
   expects.
 - `.exp`, the signed JWT lifetime, as a
   [duration](https://pkg.go.dev/time#ParseDuration). Allowed only with `.jwkPath`
-  or `.jwkEnv` — the sources whose lifetime `flux-mirror` controls — and defaults
+  or `.jwkValue` — the sources whose lifetime `flux-mirror` controls — and defaults
   to `60s`. A longer-lived token is cached and re-minted at half its lifetime.
   Every other source's lifetime is fixed by its issuer.
-- `.username`, controls how the resolved credential is transported, and therefore
+- `.hosts[].username`, controls how the resolved credential is transported, and therefore
   what the registry must accept — see
   [Bearer token vs. username/password](#bearer-token-vs-usernamepassword).
 
@@ -370,7 +369,7 @@ directory is used as the confinement root instead.
 
 ##### Bearer token vs. username/password
 
-`.hosts[].credential.username` controls how the resolved credential is
+`.hosts[].username` controls how the resolved credential is
 transported, and therefore what the registry on the other side must accept:
 
 - **`username` unset (default)** — the credential is treated as a **bearer
@@ -423,15 +422,14 @@ and ignore it. It is not allowed on a `provider` host. The field has two
 independent halves, of which at least one must be set:
 
 - `.serverAuth`, how the registry's server certificate is verified. Set exactly
-  one of `.fromPath` / `.fromEnv` / `.fromBytes` to supply a custom CA bundle
+  one of `.fromPath` / `.value` to supply a custom CA bundle
   (one or more concatenated PEM certificates), or `.spiffe` to verify the
   server's X.509-SVID against the SPIFFE trust bundle. When `.serverAuth` is
   omitted entirely, the system trust pool is used.
 - `.clientAuth`, the client certificate for mTLS. Set exactly one of `.provider:
   x509-svid` (present a SPIFFE X.509-SVID from the Workload API) or the static
   `.certificate` + `.key` pair. The `.certificate` is one of
-  `.fromPath`/`.fromEnv`/`.fromBytes`; the `.key` is one of `.fromPath`/`.fromEnv`
-  (a private key cannot be inlined, so there is no `.fromBytes`).
+  `.fromPath`/`.value`; the `.key` is one of `.fromPath`/`.value`.
 
 Each half chooses SPIFFE or non-SPIFFE independently, so SPIFFE can authenticate
 the client while a normal or custom CA verifies the server, or vice versa. Under

--- a/docs/config/config-v1beta1.json
+++ b/docs/config/config-v1beta1.json
@@ -183,11 +183,7 @@
                 "type": "string"
               },
               "exp": {
-                "description": "Exp is the jwkPath/jwkEnv JWT lifetime. Defaults to 60s.",
-                "type": "string"
-              },
-              "fromEnv": {
-                "description": "FromEnv sends a static JWT read from the named environment variable.",
+                "description": "Exp is the jwkPath/jwkValue JWT lifetime. Defaults to 60s.",
                 "type": "string"
               },
               "fromPath": {
@@ -195,15 +191,15 @@
                 "type": "string"
               },
               "iss": {
-                "description": "Iss is the issuer claim for jwkPath/jwkEnv-signed tokens.",
-                "type": "string"
-              },
-              "jwkEnv": {
-                "description": "JWKEnv signs a fresh JWT with the private JSON Web Key read from the named\nenvironment variable.",
+                "description": "Iss is the issuer claim for jwkPath/jwkValue-signed tokens.",
                 "type": "string"
               },
               "jwkPath": {
                 "description": "JWKPath signs a fresh JWT with the private JSON Web Key at the path.",
+                "type": "string"
+              },
+              "jwkValue": {
+                "description": "JWKValue signs a fresh JWT with the private JSON Web Key read from the config.",
                 "type": "string"
               },
               "provider": {
@@ -219,11 +215,11 @@
                 "type": "string"
               },
               "sub": {
-                "description": "Sub is the subject claim for jwkPath/jwkEnv-signed tokens.",
+                "description": "Sub is the subject claim for jwkPath/jwkValue-signed tokens.",
                 "type": "string"
               },
-              "username": {
-                "description": "Username presents the credential as a username/password pair.",
+              "value": {
+                "description": "Value sends a static JWT read from the config.",
                 "type": "string"
               }
             },
@@ -259,16 +255,12 @@
                     "additionalProperties": false,
                     "description": "Certificate is the static client certificate chain.",
                     "properties": {
-                      "fromBytes": {
-                        "description": "FromBytes inlines the PEM-encoded value.",
-                        "type": "string"
-                      },
-                      "fromEnv": {
-                        "description": "FromEnv reads the value from the named environment variable.",
-                        "type": "string"
-                      },
                       "fromPath": {
                         "description": "FromPath reads the value from the file at the path.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value inlines the PEM-encoded value.",
                         "type": "string"
                       }
                     },
@@ -278,12 +270,12 @@
                     "additionalProperties": false,
                     "description": "Key is the static client private key.",
                     "properties": {
-                      "fromEnv": {
-                        "description": "FromEnv reads the private key from the named environment variable.",
-                        "type": "string"
-                      },
                       "fromPath": {
                         "description": "FromPath reads the private key from the file at the path.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value reads the private key from the config.",
                         "type": "string"
                       }
                     },
@@ -303,14 +295,6 @@
                 "additionalProperties": false,
                 "description": "ServerAuth verifies the registry's server certificate.",
                 "properties": {
-                  "fromBytes": {
-                    "description": "FromBytes inlines the PEM-encoded CA bundle.",
-                    "type": "string"
-                  },
-                  "fromEnv": {
-                    "description": "FromEnv reads the CA bundle from the named environment variable.",
-                    "type": "string"
-                  },
                   "fromPath": {
                     "description": "FromPath reads the CA bundle from the file at the path.",
                     "type": "string"
@@ -333,12 +317,20 @@
                       }
                     },
                     "type": "object"
+                  },
+                  "value": {
+                    "description": "Value inlines the PEM-encoded CA bundle.",
+                    "type": "string"
                   }
                 },
                 "type": "object"
               }
             },
             "type": "object"
+          },
+          "username": {
+            "description": "Username presents the host credential as a username/password pair. When\nunset, the host credential is used as a bearer token.",
+            "type": "string"
           }
         },
         "required": [

--- a/docs/guides/keygen.md
+++ b/docs/guides/keygen.md
@@ -54,7 +54,7 @@ Output:
 
 ## Example: mint a long-lived login token
 
-Unlike `provider`/`fromEnv` credentials — whose lifetime is fixed by an external
+Unlike `provider`/`value` credentials — whose lifetime is fixed by an external
 issuer — a `jwkPath` credential is signed locally, so you control its lifetime
 through [`exp`](../config/README.md#per-host-credential). This makes a key pair plus
 `login` a convenient way to mint a single, long-lived bearer token (for example,

--- a/docs/guides/login.md
+++ b/docs/guides/login.md
@@ -32,7 +32,8 @@ The config path is resolved as: the `--config`/`-f` flag, else
 | `--plaintext`     | `false`                          | Store the credential base64-encoded in `config.json`, bypassing any OS keychain credential helper.    |
 
 The global `--timeout` flag (default `1m`) bounds credential resolution, which
-for `provider` sources involves a network call to mint the token.
+for `provider` sources involves a network call to mint the token. The global
+`--no-envsubst` flag disables config environment substitution.
 
 ## Where the credential goes
 
@@ -128,7 +129,7 @@ jobs:
 
 GHCR authorizes by the token and ignores the username value, but it still expects
 a username/password login — so set `username` to any value (for example a
-`github.*` context key) and pass `GITHUB_TOKEN` as the password via `fromEnv`:
+`github.*` context key) and pass `GITHUB_TOKEN` as the password via `value`:
 
 ```yaml
 # hosts.yaml
@@ -136,9 +137,9 @@ apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 hosts:
   - host: ghcr.io
+    username: ${GITHUB_REPOSITORY_OWNER}   # ignored by GHCR; any value works
     credential:
-      username: ${GITHUB_REPOSITORY_OWNER}   # ignored by GHCR; any value works
-      fromEnv: GH_TOKEN
+      value: ${GH_TOKEN}
 ```
 
 ```yaml
@@ -152,8 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: fluxcd/flux-mirror/actions/setup@main
-      - run: envsubst '${GITHUB_REPOSITORY_OWNER}' < hosts.yaml > rendered.yaml
-      - run: flux-mirror login -f ./rendered.yaml
+      - run: flux-mirror login -f ./hosts.yaml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
@@ -164,7 +164,7 @@ jobs:
 ### Log in to Docker Hub from GitHub Actions
 
 Docker Hub uses a standard username/password login. Set `username` to the Docker
-Hub account and pass an access token as the password via `fromEnv`:
+Hub account and pass an access token as the password via `value`:
 
 ```yaml
 # hosts.yaml
@@ -172,9 +172,9 @@ apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 hosts:
   - host: docker.io
+    username: ${DOCKERHUB_USERNAME}
     credential:
-      username: ${DOCKERHUB_USERNAME}
-      fromEnv: DOCKERHUB_TOKEN
+      value: ${DOCKERHUB_TOKEN}
 ```
 
 ```yaml
@@ -220,10 +220,10 @@ flux-mirror login --plaintext
 ## Notes
 
 - The credential is short-lived (a freshly minted provider token, a signed JWT,
-  or whatever `fromEnv`/`fromPath` holds). Re-run `login` before it expires; for
+  or whatever `value`/`fromPath` holds). Re-run `login` before it expires; for
   `provider` sources the registry re-validates each request, so a stored
   credential stops working once it lapses. To mint a longer-lived login token,
-  use a `jwkPath`/`jwkEnv` credential with a longer `exp` — see
+  use a `jwkPath`/`jwkValue` credential with a longer `exp` — see
   [keygen](./keygen.md).
 - For `aws`, the credential is a JWT-shaped envelope wrapping a signed
   `sts:GetCallerIdentity` request, not an OIDC token. The destination registry

--- a/docs/guides/secret.md
+++ b/docs/guides/secret.md
@@ -46,7 +46,8 @@ defaults to the one from the active kubeconfig context, or the in-cluster
 ServiceAccount namespace when running inside a pod.
 
 The global `--timeout` flag (default `1m`) bounds credential resolution, which
-for `provider` sources involves a network call to mint the token.
+for `provider` sources involves a network call to mint the token. The global
+`--no-envsubst` flag disables config environment substitution.
 
 ## Behavior
 
@@ -219,8 +220,8 @@ apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 hosts:
   - host: registry.example.com
+    username: sa-oidc          # value the registry expects; often ignored
     credential:
-      username: sa-oidc          # value the registry expects; often ignored
       fromPath: registry-token   # the audience is set by the projected volume
 ```
 
@@ -281,9 +282,9 @@ apiVersion: mirror.fluxcd.io/v1beta1
 kind: Config
 hosts:
   - host: registry.example.com
+    username: spiffe           # value the registry expects; often ignored
     credential:
       provider: jwt-svid
-      username: spiffe           # value the registry expects; often ignored
       # aud defaults to the host (registry.example.com)
 ```
 

--- a/docs/guides/sync.md
+++ b/docs/guides/sync.md
@@ -72,6 +72,8 @@ repository credentials automatically.
 | `--no-progress`                 | `false` | Disable the live progress spinner. Per-job lines and the summary still print.                                                       |
 | `--insecure`                    | `false` | Allow plaintext HTTP and skip TLS verification. Test/dev only.                                                                      |
 
+Global flags: `--timeout` sets the default operation timeout, and `--no-envsubst` disables config environment substitution.
+
 ## Output
 
 ### Text mode (default)
@@ -212,9 +214,9 @@ hosts:
   # username is any non-empty value; GHCR authorizes by the token), so `username`
   # is set and GITHUB_TOKEN is the password.
   - host: ghcr.io
+    username: my-org
     credential:
-      username: my-org
-      fromEnv: GH_TOKEN
+      value: ${GH_TOKEN}
 ```
 
 Each chart lands at `ghcr.io/my-org/charts/<name>:<version>`. Run it from GitHub
@@ -287,22 +289,17 @@ artifacts:
 hosts:
   # Source: authenticate to GHCR to avoid anonymous rate limits.
   - host: ghcr.io
+    username: my-org
     credential:
-      username: my-org
-      fromEnv: GH_TOKEN
+      value: ${GH_TOKEN}
   # Destination: a private registry expecting a username/password login. The
-  # password is read from the environment; the username is substituted into the
-  # config in CI (see the envsubst step below).
+  # username and password are substituted from the environment while loading the
+  # config.
   - host: registry.internal.example.com
+    username: ${REGISTRY_USERNAME}
     credential:
-      username: ${REGISTRY_USERNAME}
-      fromEnv: REGISTRY_PASSWORD
+      value: ${REGISTRY_PASSWORD}
 ```
-
-> **Note:** `credential.username` is a literal string in the config — it is not
-> an env reference. To source it from a secret, substitute it before running
-> `sync` (e.g. with `envsubst`, as below). Only the password is read at runtime
-> from the environment via `fromEnv`.
 
 ```yaml
 # .github/workflows/mirror-images.yaml
@@ -357,9 +354,9 @@ artifacts:
     selector: { regex: { pattern: "^latest$" }, sortBy: alphabetical }
 hosts:
   - host: ghcr.io
+    username: my-org
     credential:
-      username: my-org
-      fromEnv: GH_TOKEN
+      value: ${GH_TOKEN}
   - host: 123456789012.dkr.ecr.us-east-1.amazonaws.com
     provider: ecr
 ```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/distribution/distribution/v3 v3.1.1
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/fluxcd/pkg/auth v0.52.0
+	github.com/fluxcd/pkg/envsubst v1.7.0
 	github.com/fluxcd/pkg/helmtestserver v0.39.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/fluxcd/pkg/auth v0.52.0 h1:MsHKQjSOFE13DE8lZu5tDPX3SIct2KfRZwzt5B5I73
 github.com/fluxcd/pkg/auth v0.52.0/go.mod h1:GWDfC5KhljE1ekKlfXVmod8H0uUm95ISlaAXULq2euk=
 github.com/fluxcd/pkg/cache v0.14.0 h1:wEwJA8NhYj+nH9P6ifcsglDZARWlcbxbmwngGOzfU4c=
 github.com/fluxcd/pkg/cache v0.14.0/go.mod h1:KwzU2gyVQ83YOHJsbBeveJ0HsXmLrH0I668zX19d/+s=
+github.com/fluxcd/pkg/envsubst v1.7.0 h1:PL9Nj/V2fgaMR9KYZR7mEEw+vlYgP80nFZjOQQKAfJs=
+github.com/fluxcd/pkg/envsubst v1.7.0/go.mod h1:aoWeSIOamhqBZ3bHVj1GDwpdA10DXrI8yYbyjPiFly0=
 github.com/fluxcd/pkg/helmtestserver v0.39.0 h1:ijmSe54BGWp6kRKt0WqtT8fBfTOYhV67hKaaHWg0kvs=
 github.com/fluxcd/pkg/helmtestserver v0.39.0/go.mod h1:z4beyhZLAMmGkk0vdY6VWX+C++Jp1gnGhVj2NcXOqN8=
 github.com/fluxcd/pkg/testserver v0.14.0 h1:wVv/JPY3i4OEJ8xakfriuN2oHiUyZZ+BfhC/6RCD2nI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/fluxcd/pkg/envsubst"
+
 	"github.com/Masterminds/semver/v3"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -22,12 +24,26 @@ import (
 
 // Decode reads YAML from r into a Config without validating it.
 func Decode(r io.Reader) (*apiv1.Config, error) {
+	return DecodeWithEnvSubst(r, true)
+}
+
+// DecodeWithEnvSubst reads YAML from r into a Config, optionally applying
+// strict environment variable substitution before parsing.
+func DecodeWithEnvSubst(r io.Reader, substitute bool) (*apiv1.Config, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
+	rendered := data
+	if substitute {
+		out, err := envsubst.EvalEnv(string(data), true)
+		if err != nil {
+			return nil, fmt.Errorf("substitute environment variables: %w", err)
+		}
+		rendered = []byte(out)
+	}
 	var cfg apiv1.Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal(rendered, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 	return &cfg, nil
@@ -134,6 +150,9 @@ func validateHost(h apiv1.RegistryHost) error {
 		return fmt.Errorf("host is required")
 	}
 	provider := strings.TrimSpace(h.Provider)
+	if strings.TrimSpace(h.Username) != "" && h.Credential == nil {
+		return fmt.Errorf("username requires credential")
+	}
 	if h.Credential != nil && provider != "" {
 		return fmt.Errorf("credential and provider are mutually exclusive")
 	}
@@ -203,11 +222,10 @@ func validateTLS(t apiv1.TLS) error {
 func validateTLSServerAuth(s apiv1.TLSServerAuth) error {
 	if countTrue(
 		strings.TrimSpace(s.FromPath) != "",
-		strings.TrimSpace(s.FromEnv) != "",
-		strings.TrimSpace(s.FromBytes) != "",
+		strings.TrimSpace(s.Value) != "",
 		s.SPIFFE != nil,
 	) != 1 {
-		return fmt.Errorf("exactly one of fromPath, fromEnv, fromBytes, or spiffe must be set")
+		return fmt.Errorf("exactly one of fromPath, value, or spiffe must be set")
 	}
 	if s.SPIFFE != nil {
 		if err := validateSPIFFE(*s.SPIFFE); err != nil {
@@ -221,22 +239,20 @@ func validateTLSServerAuth(s apiv1.TLSServerAuth) error {
 func validateTLSData(d apiv1.TLSData) error {
 	if countTrue(
 		strings.TrimSpace(d.FromPath) != "",
-		strings.TrimSpace(d.FromEnv) != "",
-		strings.TrimSpace(d.FromBytes) != "",
+		strings.TrimSpace(d.Value) != "",
 	) != 1 {
-		return fmt.Errorf("exactly one of fromPath, fromEnv, or fromBytes must be set")
+		return fmt.Errorf("exactly one of fromPath or value must be set")
 	}
 	return nil
 }
 
-// validateTLSKey checks that exactly one source is set. A private key cannot be
-// inlined.
+// validateTLSKey checks that exactly one source is set.
 func validateTLSKey(k apiv1.TLSKey) error {
 	if countTrue(
 		strings.TrimSpace(k.FromPath) != "",
-		strings.TrimSpace(k.FromEnv) != "",
+		strings.TrimSpace(k.Value) != "",
 	) != 1 {
-		return fmt.Errorf("exactly one of fromPath or fromEnv must be set")
+		return fmt.Errorf("exactly one of fromPath or value must be set")
 	}
 	return nil
 }
@@ -293,13 +309,13 @@ func validateSPIFFE(s apiv1.SPIFFETLS) error {
 
 func validateCredential(j apiv1.RegistryCredential) error {
 	provider := strings.TrimSpace(j.Provider)
-	fromEnv := strings.TrimSpace(j.FromEnv)
+	value := strings.TrimSpace(j.Value)
 	fromPath := strings.TrimSpace(j.FromPath)
 	jwkPath := strings.TrimSpace(j.JWKPath)
-	jwkEnv := strings.TrimSpace(j.JWKEnv)
+	jwkValue := strings.TrimSpace(j.JWKValue)
 
-	if countTrue(provider != "", fromEnv != "", fromPath != "", jwkPath != "", jwkEnv != "") != 1 {
-		return fmt.Errorf("exactly one of provider, fromEnv, fromPath, jwkPath, or jwkEnv must be set")
+	if countTrue(provider != "", value != "", fromPath != "", jwkPath != "", jwkValue != "") != 1 {
+		return fmt.Errorf("exactly one of provider, value, fromPath, jwkPath, or jwkValue must be set")
 	}
 
 	hasIss := strings.TrimSpace(j.Iss) != ""
@@ -308,12 +324,12 @@ func validateCredential(j apiv1.RegistryCredential) error {
 	hasExp := j.Exp != nil
 
 	switch {
-	case jwkPath != "", jwkEnv != "":
+	case jwkPath != "", jwkValue != "":
 		if !hasIss {
-			return fmt.Errorf("iss is required with jwkPath or jwkEnv")
+			return fmt.Errorf("iss is required with jwkPath or jwkValue")
 		}
 		if !hasSub {
-			return fmt.Errorf("sub is required with jwkPath or jwkEnv")
+			return fmt.Errorf("sub is required with jwkPath or jwkValue")
 		}
 		if hasExp && j.Exp.Duration <= 0 {
 			return fmt.Errorf("exp must be a positive duration")
@@ -326,20 +342,20 @@ func validateCredential(j apiv1.RegistryCredential) error {
 				provider, apiv1.JWTProviderGitHub, apiv1.JWTProviderForgejo, apiv1.JWTProviderGCP, apiv1.JWTProviderAzure, apiv1.JWTProviderAWS, apiv1.JWTProviderJWTSVID)
 		}
 		if hasIss || hasSub {
-			return fmt.Errorf("iss and sub can only be set with jwkPath or jwkEnv")
+			return fmt.Errorf("iss and sub can only be set with jwkPath or jwkValue")
 		}
 		if hasExp {
-			return fmt.Errorf("exp can only be set with jwkPath or jwkEnv")
+			return fmt.Errorf("exp can only be set with jwkPath or jwkValue")
 		}
-	case fromEnv != "", fromPath != "":
+	case value != "", fromPath != "":
 		if hasIss || hasSub {
-			return fmt.Errorf("iss and sub can only be set with jwkPath or jwkEnv")
+			return fmt.Errorf("iss and sub can only be set with jwkPath or jwkValue")
 		}
 		if hasAud {
-			return fmt.Errorf("aud can only be set with jwkPath, jwkEnv, or provider")
+			return fmt.Errorf("aud can only be set with jwkPath, jwkValue, or provider")
 		}
 		if hasExp {
-			return fmt.Errorf("exp can only be set with jwkPath or jwkEnv")
+			return fmt.Errorf("exp can only be set with jwkPath or jwkValue")
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -71,6 +72,96 @@ artifacts:
 	g.Expect(cfg.Artifacts[1].Selector.EffectiveSortBy()).To(Equal(SortByNumerical))
 }
 
+func TestDecode_EnvSubstitution(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("CREDENTIAL_KEY", "value")
+	t.Setenv("REGISTRY_TOKEN", "env-token")
+
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      ${CREDENTIAL_KEY}: ${REGISTRY_TOKEN}
+`
+	cfg, err := Decode(strings.NewReader(src))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Hosts).To(HaveLen(1))
+	g.Expect(cfg.Hosts[0].Credential.Value).To(Equal("env-token"))
+}
+
+func TestDecode_EnvSubstitutionIgnoresSingleDollar(t *testing.T) {
+	g := NewWithT(t)
+
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+artifacts:
+  - source: ghcr.io/a/b
+    destination: ghcr.io/c/d
+    selector:
+      regex:
+        pattern: .*
+        extract: "$patch"
+`
+	cfg, err := Decode(strings.NewReader(src))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Artifacts[0].Selector.Regex.Extract).To(Equal("$patch"))
+}
+
+func TestDecodeWithEnvSubstDisabled(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("REGISTRY_TOKEN", "env-token")
+
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      value: ${REGISTRY_TOKEN}
+`
+	cfg, err := DecodeWithEnvSubst(strings.NewReader(src), false)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Hosts[0].Credential.Value).To(Equal("${REGISTRY_TOKEN}"))
+}
+
+func TestDecode_EnvSubstitutionStrict(t *testing.T) {
+	g := NewWithT(t)
+	const missingToken = "FLUX_MIRROR_TEST_MISSING_TOKEN_STRICT"
+	old, hadOld := os.LookupEnv(missingToken)
+	g.Expect(os.Unsetenv(missingToken)).To(Succeed())
+	t.Cleanup(func() {
+		if hadOld {
+			_ = os.Setenv(missingToken, old)
+		}
+	})
+
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      value: ${FLUX_MIRROR_TEST_MISSING_TOKEN_STRICT}
+`
+	_, err := Decode(strings.NewReader(src))
+	g.Expect(err).To(MatchError(ContainSubstring("substitute environment variables")))
+}
+
+func TestDecode_EnvSubstitutionStrictAllowsEmpty(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("EMPTY_TOKEN", "")
+
+	src := `apiVersion: mirror.fluxcd.io/v1beta1
+kind: Config
+hosts:
+  - host: registry.example.com
+    credential:
+      value: ${EMPTY_TOKEN}
+`
+	cfg, err := Decode(strings.NewReader(src))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Hosts[0].Credential.Value).To(BeEmpty())
+}
+
 func TestDefaults(t *testing.T) {
 	g := NewWithT(t)
 
@@ -100,7 +191,7 @@ func TestResolvePaths(t *testing.T) {
 				ServerAuth: &TLSServerAuth{FromPath: "../../etc/shadow"}, // traversal: clamped
 				ClientAuth: &TLSClientAuth{
 					Certificate: &TLSData{FromPath: "certs/client.crt"},
-					Key:         &TLSKey{FromEnv: "CLIENT_KEY"}, // not a path: untouched
+					Key:         &TLSKey{Value: "CLIENT_KEY"}, // not a path: untouched
 				},
 			},
 		}}}
@@ -115,7 +206,7 @@ func TestResolvePaths(t *testing.T) {
 	g.Expect(h.Credential.JWKPath).To(Equal("/etc/flux-mirror/abs/keys/jwk.json"))
 	g.Expect(h.TLS.ServerAuth.FromPath).To(Equal("/etc/flux-mirror/etc/shadow")) // escape clamped
 	g.Expect(h.TLS.ClientAuth.Certificate.FromPath).To(Equal("/etc/flux-mirror/certs/client.crt"))
-	g.Expect(h.TLS.ClientAuth.Key.FromEnv).To(Equal("CLIENT_KEY"))
+	g.Expect(h.TLS.ClientAuth.Key.Value).To(Equal("CLIENT_KEY"))
 
 	// Empty baseDir is a no-op: paths stay as written.
 	cfg = mkCfg()
@@ -314,10 +405,10 @@ func TestValidate_Table(t *testing.T) {
 				}}},
 		},
 		{
-			name: "auth valid fromEnv",
+			name: "auth valid value",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
-					Host: "static.example", Credential: &RegistryCredential{FromEnv: "TOKEN"},
+					Host: "static.example", Credential: &RegistryCredential{Value: "TOKEN"},
 				}}},
 		},
 		{
@@ -347,34 +438,34 @@ func TestValidate_Table(t *testing.T) {
 				}}},
 		},
 		{
-			name: "auth valid jwkEnv",
+			name: "auth valid jwkValue",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
 					Host: "registry.example", Credential: &RegistryCredential{
-						JWKEnv: "REGISTRY_JWK", Iss: "https://issuer", Sub: "client", Aud: "registry.example",
+						JWKValue: "REGISTRY_JWK", Iss: "https://issuer", Sub: "client", Aud: "registry.example",
 						Exp: &metav1.Duration{Duration: time.Hour},
 					},
 				}}},
 		},
 		{
-			name: "auth jwkEnv missing iss",
+			name: "auth jwkValue missing iss",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
 					Host: "registry.example", Credential: &RegistryCredential{
-						JWKEnv: "REGISTRY_JWK", Sub: "client",
+						JWKValue: "REGISTRY_JWK", Sub: "client",
 					},
 				}}},
-			errMsg: "iss is required with jwkPath or jwkEnv",
+			errMsg: "iss is required with jwkPath or jwkValue",
 		},
 		{
-			name: "auth jwkPath and jwkEnv both set",
+			name: "auth jwkPath and jwkValue both set",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
 					Host: "registry.example", Credential: &RegistryCredential{
-						JWKPath: "/path/jwk.json", JWKEnv: "REGISTRY_JWK", Iss: "https://issuer", Sub: "client",
+						JWKPath: "/path/jwk.json", JWKValue: "REGISTRY_JWK", Iss: "https://issuer", Sub: "client",
 					},
 				}}},
-			errMsg: "exactly one of provider, fromEnv, fromPath, jwkPath, or jwkEnv",
+			errMsg: "exactly one of provider, value, fromPath, jwkPath, or jwkValue",
 		},
 		{
 			name: "auth jwkPath exp non-positive",
@@ -398,11 +489,11 @@ func TestValidate_Table(t *testing.T) {
 			errMsg: "exp can only be set with jwkPath",
 		},
 		{
-			name: "auth exp rejected with fromEnv",
+			name: "auth exp rejected with value",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
 					Host: "registry.example", Credential: &RegistryCredential{
-						FromEnv: "TOKEN", Exp: &metav1.Duration{Duration: time.Hour},
+						Value: "TOKEN", Exp: &metav1.Duration{Duration: time.Hour},
 					},
 				}}},
 			errMsg: "exp can only be set with jwkPath",
@@ -410,7 +501,7 @@ func TestValidate_Table(t *testing.T) {
 		{
 			name: "auth missing host",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
-				Hosts: []RegistryHost{{Credential: &RegistryCredential{FromEnv: "TOKEN"}}}},
+				Hosts: []RegistryHost{{Credential: &RegistryCredential{Value: "TOKEN"}}}},
 			errMsg: "host is required",
 		},
 		{
@@ -448,7 +539,7 @@ func TestValidate_Table(t *testing.T) {
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{
 					Host: "h.example", Provider: RegistryProviderGAR,
-					Credential: &RegistryCredential{FromEnv: "TOKEN"},
+					Credential: &RegistryCredential{Value: "TOKEN"},
 				}}},
 			errMsg: "credential and provider are mutually exclusive",
 		},
@@ -456,8 +547,8 @@ func TestValidate_Table(t *testing.T) {
 			name: "auth duplicate host",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{
-					{Host: "dup.example", Credential: &RegistryCredential{FromEnv: "A"}},
-					{Host: "dup.example", Credential: &RegistryCredential{FromEnv: "B"}},
+					{Host: "dup.example", Credential: &RegistryCredential{Value: "A"}},
+					{Host: "dup.example", Credential: &RegistryCredential{Value: "B"}},
 				}},
 			errMsg: "configured more than once",
 		},
@@ -465,15 +556,15 @@ func TestValidate_Table(t *testing.T) {
 			name: "auth no source set",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example", Credential: &RegistryCredential{}}}},
-			errMsg: "exactly one of provider, fromEnv, fromPath, jwkPath, or jwkEnv",
+			errMsg: "exactly one of provider, value, fromPath, jwkPath, or jwkValue",
 		},
 		{
 			name: "auth two sources set",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example", Credential: &RegistryCredential{
-					Provider: JWTProviderGitHub, FromEnv: "TOKEN",
+					Provider: JWTProviderGitHub, Value: "TOKEN",
 				}}}},
-			errMsg: "exactly one of provider, fromEnv, fromPath, jwkPath, or jwkEnv",
+			errMsg: "exactly one of provider, value, fromPath, jwkPath, or jwkValue",
 		},
 		{
 			name: "auth invalid provider",
@@ -508,12 +599,12 @@ func TestValidate_Table(t *testing.T) {
 			errMsg: "iss and sub can only be set with jwkPath",
 		},
 		{
-			name: "auth aud set with fromEnv",
+			name: "auth aud set with value",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example", Credential: &RegistryCredential{
-					FromEnv: "TOKEN", Aud: "nope",
+					Value: "TOKEN", Aud: "nope",
 				}}}},
-			errMsg: "aud can only be set with jwkPath, jwkEnv, or provider",
+			errMsg: "aud can only be set with jwkPath, jwkValue, or provider",
 		},
 		{
 			name: "auth aud set with fromPath",
@@ -521,7 +612,7 @@ func TestValidate_Table(t *testing.T) {
 				Hosts: []RegistryHost{{Host: "h.example", Credential: &RegistryCredential{
 					FromPath: "/path/token", Aud: "nope",
 				}}}},
-			errMsg: "aud can only be set with jwkPath, jwkEnv, or provider",
+			errMsg: "aud can only be set with jwkPath, jwkValue, or provider",
 		},
 		{
 			name: "auth iss set with fromPath",
@@ -532,12 +623,12 @@ func TestValidate_Table(t *testing.T) {
 			errMsg: "iss and sub can only be set with jwkPath",
 		},
 		{
-			name: "auth fromPath and fromEnv set",
+			name: "auth fromPath and value set",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example", Credential: &RegistryCredential{
-					FromEnv: "TOKEN", FromPath: "/path/token",
+					Value: "TOKEN", FromPath: "/path/token",
 				}}}},
-			errMsg: "exactly one of provider, fromEnv, fromPath, jwkPath, or jwkEnv",
+			errMsg: "exactly one of provider, value, fromPath, jwkPath, or jwkValue",
 		},
 		{
 			name: "credential provider jwt-svid is valid",
@@ -565,7 +656,7 @@ func TestValidate_Table(t *testing.T) {
 			name: "tls credential and tls together is valid",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example",
-					Credential: &RegistryCredential{FromEnv: "TOKEN"},
+					Credential: &RegistryCredential{Value: "TOKEN"},
 					TLS:        &TLS{ClientAuth: &TLSClientAuth{Certificate: &TLSData{FromPath: "/c.crt"}, Key: &TLSKey{FromPath: "/c.key"}}},
 				}}},
 		},
@@ -595,9 +686,9 @@ func TestValidate_Table(t *testing.T) {
 			name: "tls serverAuth two sources",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: validArtifact(),
 				Hosts: []RegistryHost{{Host: "h.example", TLS: &TLS{
-					ServerAuth: &TLSServerAuth{FromPath: "/ca.crt", FromEnv: "CA"},
+					ServerAuth: &TLSServerAuth{FromPath: "/ca.crt", Value: "CA"},
 				}}}},
-			errMsg: "serverAuth: exactly one of fromPath, fromEnv, fromBytes, or spiffe",
+			errMsg: "serverAuth: exactly one of fromPath, value, or spiffe",
 		},
 		{
 			name: "tls serverAuth ca and spiffe together",
@@ -605,7 +696,7 @@ func TestValidate_Table(t *testing.T) {
 				Hosts: []RegistryHost{{Host: "h.example", TLS: &TLS{
 					ServerAuth: &TLSServerAuth{FromPath: "/ca.crt", SPIFFE: &SPIFFETLS{AuthorizeAny: true}},
 				}}}},
-			errMsg: "serverAuth: exactly one of fromPath, fromEnv, fromBytes, or spiffe",
+			errMsg: "serverAuth: exactly one of fromPath, value, or spiffe",
 		},
 		{
 			name: "tls clientAuth missing key",

--- a/internal/registryauth/credential.go
+++ b/internal/registryauth/credential.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package registryauth resolves OCI registry credentials for the hosts in a
-// flux-mirror config's hosts section: JWT credentials (provider/fromEnv/fromPath/
-// jwkPath/jwkEnv) and cloud registry providers (ecr/acr/gar). It is the auth layer
+// flux-mirror config's hosts section: JWT credentials (provider/value/fromPath/
+// jwkPath/jwkValue) and cloud registry providers (ecr/acr/gar). It is the auth layer
 // shared by the sync, login, and create commands.
 package registryauth
 
@@ -50,15 +50,15 @@ func resolveCredential(ctx context.Context, h apiv1.RegistryHost) (string, error
 			return "", err
 		}
 		return fn(ctx)
-	case c.FromEnv != "":
-		return requireEnv(c.FromEnv)
+	case c.Value != "":
+		return c.Value, nil
 	case c.FromPath != "":
 		b, err := os.ReadFile(c.FromPath)
 		if err != nil {
 			return "", fmt.Errorf("read fromPath: %w", err)
 		}
 		return strings.TrimSpace(string(b)), nil
-	case c.JWKPath != "", c.JWKEnv != "":
+	case c.JWKPath != "", c.JWKValue != "":
 		raw, err := readJWK(c)
 		if err != nil {
 			return "", err
@@ -75,7 +75,7 @@ func resolveCredential(ctx context.Context, h apiv1.RegistryHost) (string, error
 
 // jwkTokenFunc parses a private JWK once and returns a cijwt.TokenFunc that
 // signs a fresh JWT with the given claims and lifetime on each call. Used for
-// jwkPath/jwkEnv credentials that set a custom exp; the default 60s lifetime is
+// jwkPath/jwkValue credentials that set a custom exp; the default 60s lifetime is
 // served by cijwt.WithHostJWK instead.
 func jwkTokenFunc(jwk, iss, sub, aud string, ttl time.Duration) (cijwt.TokenFunc, error) {
 	key, err := jwt.ParseJWK(jwk)

--- a/internal/registryauth/registryauth.go
+++ b/internal/registryauth/registryauth.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 
@@ -88,8 +87,8 @@ func ResolveHostAuth(ctx context.Context, h apiv1.RegistryHost) (HostAuth, error
 	if err != nil {
 		return HostAuth{}, err
 	}
-	if h.Credential.Username != "" {
-		return HostAuth{Username: h.Credential.Username, Password: cred}, nil
+	if h.Username != "" {
+		return HostAuth{Username: h.Username, Password: cred}, nil
 	}
 	return HostAuth{RegistryToken: cred}, nil
 }
@@ -163,7 +162,7 @@ func (m mintingAuthenticator) AuthorizationContext(ctx context.Context) (*authn.
 	if err != nil {
 		return nil, err
 	}
-	return &authn.AuthConfig{Username: m.host.Credential.Username, Password: cred}, nil
+	return &authn.AuthConfig{Username: m.host.Username, Password: cred}, nil
 }
 
 // BuildKeychain returns a keychain that serves the hosts which authenticate
@@ -181,7 +180,7 @@ func BuildKeychain(ctx context.Context, hosts []apiv1.RegistryHost) (authn.Keych
 				return nil, err
 			}
 			auths[h.Host] = a
-		case h.Credential != nil && h.Credential.Username != "":
+		case h.Credential != nil && h.Username != "":
 			auths[h.Host] = mintingAuthenticator{host: h}
 		}
 	}
@@ -197,7 +196,7 @@ func BuildKeychain(ctx context.Context, hosts []apiv1.RegistryHost) (authn.Keych
 // keychain instead.
 func NeedsCredentialTransport(hosts []apiv1.RegistryHost) bool {
 	for _, h := range hosts {
-		if h.Credential != nil && h.Credential.Username == "" {
+		if h.Credential != nil && h.Username == "" {
 			return true
 		}
 	}
@@ -215,29 +214,12 @@ func NewCredentialTransport(inner http.RoundTripper, hosts []apiv1.RegistryHost)
 	return cijwt.NewTransport(opts...)
 }
 
-// requireEnv reads a required environment variable, erroring if it is unset or
-// empty. It is shared by every credential source that reads straight from the
-// environment (fromEnv, jwkEnv, and the tls fromEnv source).
-func requireEnv(name string) (string, error) {
-	v := os.Getenv(name)
-	if v == "" {
-		return "", fmt.Errorf("environment variable %q is not set or empty", name)
-	}
-	return v, nil
-}
-
-// readJWK returns the private JWK for a jwkPath or jwkEnv credential, reading it
-// from the file (jwkPath) or the named environment variable (jwkEnv). Exactly
-// one of the two is set by the time this is called (enforced by validation).
+// readJWK returns the private JWK for a jwkPath or jwkValue credential. Exactly one of the two is set by the time this is called (enforced by validation).
 func readJWK(j *apiv1.RegistryCredential) (string, error) {
-	if j.JWKEnv != "" {
-		raw, err := requireEnv(j.JWKEnv)
+	if j.JWKValue != "" {
+		jwk, err := jwkio.ReadPrivateJWKFromBytes([]byte(j.JWKValue))
 		if err != nil {
-			return "", err
-		}
-		jwk, err := jwkio.ReadPrivateJWKFromBytes([]byte(raw))
-		if err != nil {
-			return "", fmt.Errorf("read jwkEnv: %w", err)
+			return "", fmt.Errorf("read jwkValue: %w", err)
 		}
 		return jwk, nil
 	}
@@ -249,16 +231,15 @@ func readJWK(j *apiv1.RegistryCredential) (string, error) {
 }
 
 // JWTTransportOptions turns the validated hosts config into cijwt options,
-// reading FromEnv environment variables and JWKPath files at this point and
+// reading Value/JWKValue fields and JWKPath files at this point and
 // wiring each Provider to its token-minting closure. FromPath is wired straight
 // to cijwt, which re-reads the file on every request. It assumes the config has
-// passed validation, so it only reports errors that need runtime state: an
-// unset env var or an unreadable key file.
+// passed validation, so it only reports errors that need runtime state: an unreadable key file.
 func JWTTransportOptions(inner http.RoundTripper, hosts []apiv1.RegistryHost) ([]cijwt.Option, error) {
 	opts := []cijwt.Option{cijwt.WithInner(inner)}
 
 	for _, h := range hosts {
-		if h.Credential == nil || h.Credential.Username != "" {
+		if h.Credential == nil || h.Username != "" {
 			// Provider hosts and username credentials authenticate via the
 			// keychain (standard challenge), not the cijwt bearer-stamp.
 			continue
@@ -272,15 +253,11 @@ func JWTTransportOptions(inner http.RoundTripper, hosts []apiv1.RegistryHost) ([
 				return nil, fmt.Errorf("auth host %q: %w", h.Host, err)
 			}
 			opts = append(opts, cijwt.WithHostTokenFunc(h.Host, fn))
-		case j.FromEnv != "":
-			token, err := requireEnv(j.FromEnv)
-			if err != nil {
-				return nil, fmt.Errorf("auth host %q: %w", h.Host, err)
-			}
-			opts = append(opts, cijwt.WithHostToken(h.Host, token))
+		case j.Value != "":
+			opts = append(opts, cijwt.WithHostToken(h.Host, j.Value))
 		case j.FromPath != "":
 			opts = append(opts, cijwt.WithHostTokenFile(h.Host, j.FromPath))
-		case j.JWKPath != "", j.JWKEnv != "":
+		case j.JWKPath != "", j.JWKValue != "":
 			jwk, err := readJWK(j)
 			if err != nil {
 				return nil, fmt.Errorf("auth host %q: %w", h.Host, err)

--- a/internal/registryauth/registryauth_test.go
+++ b/internal/registryauth/registryauth_test.go
@@ -17,7 +17,7 @@ func authHostsConfig(hosts ...string) *apiv1.Config {
 	for _, h := range hosts {
 		cfg.Hosts = append(cfg.Hosts, apiv1.RegistryHost{
 			Host:       h,
-			Credential: &apiv1.RegistryCredential{FromEnv: "X"},
+			Credential: &apiv1.RegistryCredential{Value: "X"},
 		})
 	}
 	return cfg
@@ -56,10 +56,10 @@ func TestUsernameSwitch(t *testing.T) {
 	g := NewWithT(t)
 
 	bearer := []apiv1.RegistryHost{{
-		Host: "bearer.example", Credential: &apiv1.RegistryCredential{FromEnv: "X"},
+		Host: "bearer.example", Credential: &apiv1.RegistryCredential{Value: "X"},
 	}}
 	userpass := []apiv1.RegistryHost{{
-		Host: "userpass.example", Credential: &apiv1.RegistryCredential{FromEnv: "X", Username: "robot"},
+		Host: "userpass.example", Username: "robot", Credential: &apiv1.RegistryCredential{Value: "X"},
 	}}
 
 	// cijwt (bearer-stamp) transport is needed only when a credential host has
@@ -100,9 +100,9 @@ func TestHasCredentialAndTLSOnly(t *testing.T) {
 	g := NewWithT(t)
 
 	tlsOnly := apiv1.RegistryHost{Host: "tls.example", TLS: &apiv1.TLS{
-		ServerAuth: &apiv1.TLSServerAuth{FromBytes: "x"},
+		ServerAuth: &apiv1.TLSServerAuth{Value: "x"},
 	}}
-	withCred := apiv1.RegistryHost{Host: "c.example", Credential: &apiv1.RegistryCredential{FromEnv: "X"}}
+	withCred := apiv1.RegistryHost{Host: "c.example", Credential: &apiv1.RegistryCredential{Value: "X"}}
 	withProvider := apiv1.RegistryHost{Host: "p.example", Provider: apiv1.RegistryProviderECR}
 
 	g.Expect(HasCredential(tlsOnly)).To(BeFalse())

--- a/internal/registryauth/spiffe_test.go
+++ b/internal/registryauth/spiffe_test.go
@@ -214,7 +214,7 @@ func TestSPIFFE_ClientOnly(t *testing.T) {
 	rt, closeFn, err := NewTLSTransport(context.Background(), http.DefaultTransport, []apiv1.RegistryHost{{
 		Host: host,
 		TLS: &apiv1.TLS{
-			ServerAuth: &apiv1.TLSServerAuth{FromBytes: string(ca.certPEM)},
+			ServerAuth: &apiv1.TLSServerAuth{Value: string(ca.certPEM)},
 			ClientAuth: &apiv1.TLSClientAuth{Provider: apiv1.TLSClientProviderX509SVID},
 		},
 	}})

--- a/internal/registryauth/tls.go
+++ b/internal/registryauth/tls.go
@@ -122,7 +122,7 @@ func buildTLSConfig(t *apiv1.TLS, src *workloadapi.X509Source) (*tls.Config, err
 		}
 		tlsconfig.HookTLSClientConfig(cfg, src, authorizer)
 	case t.ServerAuth != nil:
-		pemBytes, err := readPEMSource(t.ServerAuth.FromPath, t.ServerAuth.FromEnv, t.ServerAuth.FromBytes)
+		pemBytes, err := readPEMSource(t.ServerAuth.FromPath, t.ServerAuth.Value)
 		if err != nil {
 			return nil, fmt.Errorf("serverAuth: %w", err)
 		}
@@ -142,7 +142,7 @@ func buildTLSConfig(t *apiv1.TLS, src *workloadapi.X509Source) (*tls.Config, err
 		if err != nil {
 			return nil, fmt.Errorf("clientAuth: certificate: %w", err)
 		}
-		keyPEM, err := readPEMSource(t.ClientAuth.Key.FromPath, t.ClientAuth.Key.FromEnv, "")
+		keyPEM, err := readPEMSource(t.ClientAuth.Key.FromPath, t.ClientAuth.Key.Value)
 		if err != nil {
 			return nil, fmt.Errorf("clientAuth: key: %w", err)
 		}
@@ -189,12 +189,11 @@ func spiffeAuthorizer(src *workloadapi.X509Source, s *apiv1.SPIFFETLS) (tlsconfi
 
 // readTLSData reads a single PEM value from the one configured source.
 func readTLSData(d *apiv1.TLSData) ([]byte, error) {
-	return readPEMSource(d.FromPath, d.FromEnv, d.FromBytes)
+	return readPEMSource(d.FromPath, d.Value)
 }
 
-// readPEMSource reads PEM bytes from exactly one of a file path, an environment
-// variable, or an inline value.
-func readPEMSource(fromPath, fromEnv, fromBytes string) ([]byte, error) {
+// readPEMSource reads PEM bytes from exactly one of a file path or an inline value.
+func readPEMSource(fromPath, value string) ([]byte, error) {
 	switch {
 	case fromPath != "":
 		b, err := os.ReadFile(fromPath)
@@ -202,14 +201,8 @@ func readPEMSource(fromPath, fromEnv, fromBytes string) ([]byte, error) {
 			return nil, fmt.Errorf("read fromPath: %w", err)
 		}
 		return b, nil
-	case fromEnv != "":
-		v, err := requireEnv(fromEnv)
-		if err != nil {
-			return nil, err
-		}
-		return []byte(v), nil
-	case fromBytes != "":
-		return []byte(fromBytes), nil
+	case value != "":
+		return []byte(value), nil
 	default:
 		return nil, fmt.Errorf("no source set")
 	}

--- a/internal/registryauth/tls_test.go
+++ b/internal/registryauth/tls_test.go
@@ -119,9 +119,9 @@ func TestNewTLSTransport_MTLSEndToEnd(t *testing.T) {
 		rt, closeFn, err := NewTLSTransport(context.Background(), http.DefaultTransport, []apiv1.RegistryHost{{
 			Host: host,
 			TLS: &apiv1.TLS{
-				ServerAuth: &apiv1.TLSServerAuth{FromBytes: string(ca.certPEM)},
+				ServerAuth: &apiv1.TLSServerAuth{Value: string(ca.certPEM)},
 				ClientAuth: &apiv1.TLSClientAuth{
-					Certificate: &apiv1.TLSData{FromBytes: string(clientCertPEM)},
+					Certificate: &apiv1.TLSData{Value: string(clientCertPEM)},
 					Key:         &apiv1.TLSKey{FromPath: writeTemp(t, clientKeyPEM)},
 				},
 			},
@@ -138,7 +138,7 @@ func TestNewTLSTransport_MTLSEndToEnd(t *testing.T) {
 		g := NewWithT(t)
 		rt, closeFn, err := NewTLSTransport(context.Background(), http.DefaultTransport, []apiv1.RegistryHost{{
 			Host: host,
-			TLS:  &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{FromBytes: string(ca.certPEM)}},
+			TLS:  &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{Value: string(ca.certPEM)}},
 		}})
 		g.Expect(err).ToNot(HaveOccurred())
 		defer closeFn()
@@ -153,9 +153,9 @@ func TestNewTLSTransport_MTLSEndToEnd(t *testing.T) {
 		rt, closeFn, err := NewTLSTransport(context.Background(), http.DefaultTransport, []apiv1.RegistryHost{{
 			Host: host,
 			TLS: &apiv1.TLS{
-				ServerAuth: &apiv1.TLSServerAuth{FromBytes: string(otherCA.certPEM)},
+				ServerAuth: &apiv1.TLSServerAuth{Value: string(otherCA.certPEM)},
 				ClientAuth: &apiv1.TLSClientAuth{
-					Certificate: &apiv1.TLSData{FromBytes: string(clientCertPEM)},
+					Certificate: &apiv1.TLSData{Value: string(clientCertPEM)},
 					Key:         &apiv1.TLSKey{FromPath: writeTemp(t, clientKeyPEM)},
 				},
 			},
@@ -215,15 +215,15 @@ func makeCertPEM(t *testing.T) (certPEM, keyPEM []byte) {
 func TestNeedsTLS(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(NeedsTLS(nil)).To(BeFalse())
-	g.Expect(NeedsTLS([]apiv1.RegistryHost{{Host: "a", Credential: &apiv1.RegistryCredential{FromEnv: "X"}}})).To(BeFalse())
-	g.Expect(NeedsTLS([]apiv1.RegistryHost{{Host: "a", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{FromBytes: "x"}}}})).To(BeTrue())
+	g.Expect(NeedsTLS([]apiv1.RegistryHost{{Host: "a", Credential: &apiv1.RegistryCredential{Value: "X"}}})).To(BeFalse())
+	g.Expect(NeedsTLS([]apiv1.RegistryHost{{Host: "a", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{Value: "x"}}}})).To(BeTrue())
 }
 
 func TestNewTLSTransport_NoTLSReturnsInner(t *testing.T) {
 	g := NewWithT(t)
 	inner := http.DefaultTransport
 	rt, closeFn, err := NewTLSTransport(context.Background(), inner, []apiv1.RegistryHost{
-		{Host: "a", Credential: &apiv1.RegistryCredential{FromEnv: "X"}},
+		{Host: "a", Credential: &apiv1.RegistryCredential{Value: "X"}},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(rt).To(BeIdenticalTo(inner))
@@ -236,12 +236,12 @@ func TestNewTLSTransport_StaticDispatch(t *testing.T) {
 	certPEM, keyPEM := makeCertPEM(t)
 
 	hosts := []apiv1.RegistryHost{
-		{Host: "ca.example", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{FromBytes: string(caPEM)}}},
+		{Host: "ca.example", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{Value: string(caPEM)}}},
 		{Host: "mtls.example", TLS: &apiv1.TLS{ClientAuth: &apiv1.TLSClientAuth{
-			Certificate: &apiv1.TLSData{FromBytes: string(certPEM)},
+			Certificate: &apiv1.TLSData{Value: string(certPEM)},
 			Key:         &apiv1.TLSKey{FromPath: writeTemp(t, keyPEM)},
 		}}},
-		{Host: "plain.example", Credential: &apiv1.RegistryCredential{FromEnv: "X"}},
+		{Host: "plain.example", Credential: &apiv1.RegistryCredential{Value: "X"}},
 	}
 	rt, closeFn, err := NewTLSTransport(context.Background(), http.DefaultTransport, hosts)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -262,7 +262,7 @@ func TestNewTLSTransport_StaticDispatch(t *testing.T) {
 func TestNewTLSTransport_BadCABundle(t *testing.T) {
 	g := NewWithT(t)
 	_, _, err := NewTLSTransport(context.Background(), http.DefaultTransport, []apiv1.RegistryHost{
-		{Host: "ca.example", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{FromBytes: "not a pem"}}},
+		{Host: "ca.example", TLS: &apiv1.TLS{ServerAuth: &apiv1.TLSServerAuth{Value: "not a pem"}}},
 	})
 	g.Expect(err).To(MatchError(ContainSubstring("no valid certificates in CA bundle")))
 }
@@ -270,21 +270,10 @@ func TestNewTLSTransport_BadCABundle(t *testing.T) {
 func TestReadTLSData(t *testing.T) {
 	g := NewWithT(t)
 
-	// fromBytes
-	b, err := readTLSData(&apiv1.TLSData{FromBytes: "inline"})
+	// value
+	b, err := readTLSData(&apiv1.TLSData{Value: "inline"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(string(b)).To(Equal("inline"))
-
-	// fromEnv
-	t.Setenv("TLS_TEST_VAR", "envval")
-	b, err = readTLSData(&apiv1.TLSData{FromEnv: "TLS_TEST_VAR"})
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(string(b)).To(Equal("envval"))
-
-	// fromEnv unset
-	t.Setenv("TLS_TEST_VAR", "")
-	_, err = readTLSData(&apiv1.TLSData{FromEnv: "TLS_TEST_VAR"})
-	g.Expect(err).To(MatchError(ContainSubstring("is not set or empty")))
 
 	// fromPath
 	p := filepath.Join(t.TempDir(), "f")

--- a/test/podinfo.yaml
+++ b/test/podinfo.yaml
@@ -12,7 +12,7 @@ artifacts:
     selector:
       regex:
         pattern: '^6\.11\.(?P<patch>\d+)$'
-        extract: "${patch}"
+        extract: "$patch"
       sortBy: numerical
       limit: 2
     includeReferrers: true


### PR DESCRIPTION
Closes: #48

⚠️ **Breaking changes**

* Migrate `hosts[].credential.username` to `hosts[].username`. No behavior changes.
* Migrate all `fromEnv` and `fromBytes` fields to `value`.
* Migrate `jwkEnv` to `jwkValue`.

Introduce `fluxcd/pkg/envsubst` for the whole Config API, e.g.:

```yaml
hosts:
  - host: ...
    credential:
      username: a-static-user
      fromEnv: CRED_ENV
    tls:
      serverAuth:
        fromBytes: ...
```

Is now:

```yaml
hosts:
  - host: ...
    username: ${USER_ENV}
    credential:
      value: ${CRED_ENV}
    tls:
      serverAuth:
        value: ...
````

And `jwkEnv: JWK_ENV` -> `jwkValue: ${JWK_ENV}`.