### PR TITLE
fix: preserve secret metadata on replace

### DIFF
--- a/cmd/flux-mirror/secret.go
+++ b/cmd/flux-mirror/secret.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -182,6 +183,8 @@ func applySecret(ctx context.Context, client kubernetes.Interface, secret *corev
 		return false, fmt.Errorf("get existing secret: %w", err)
 	}
 	secret.ResourceVersion = existing.ResourceVersion
+	secret.Labels = maps.Clone(existing.Labels)
+	secret.Annotations = maps.Clone(existing.Annotations)
 	if _, err := secrets.Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
 		return false, fmt.Errorf("replace secret: %w", err)
 	}

--- a/cmd/flux-mirror/secret_test.go
+++ b/cmd/flux-mirror/secret_test.go
@@ -80,6 +80,35 @@ func TestApplySecret_CreateThenReplace(t *testing.T) {
 	g.Expect(parsed.Auths["a.example"].Password).To(Equal("v2"))
 }
 
+func TestApplySecret_PreservesExistingMetadataOnReplace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	client := fake.NewClientset()
+
+	s1, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{
+		"a.example": {Username: "robot", Password: "v1"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	s1.Labels = map[string]string{"app.kubernetes.io/managed-by": "cronjob"}
+	s1.Annotations = map[string]string{"example.com/rotated-by": "flux-mirror"}
+	created, err := applySecret(ctx, client, s1, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(created).To(BeTrue())
+
+	s2, err := buildDockerConfigSecret("regcreds", "flux-system", map[string]registryauth.HostAuth{
+		"a.example": {Username: "robot", Password: "v2"},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	created, err = applySecret(ctx, client, s2, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(created).To(BeFalse())
+
+	got, err := client.CoreV1().Secrets("flux-system").Get(ctx, "regcreds", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "cronjob"))
+	g.Expect(got.Annotations).To(HaveKeyWithValue("example.com/rotated-by", "flux-mirror"))
+}
+
 func TestApplySecret_CreateOnlyConflict(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/docs/guides/secret.md
+++ b/docs/guides/secret.md
@@ -54,7 +54,8 @@ for `provider` sources involves a network call to mint the token. The global
 - Works both locally (kubeconfig) and in-cluster (falls back to the in-cluster
   config and ServiceAccount namespace).
 - By default the Secret is upserted (created, or replaced if it exists). With
-  `--create`, an existing Secret of the same name is an error.
+  `--create`, an existing Secret of the same name is an error. On replace,
+  existing labels and annotations are preserved.
 - With no `--host`, every host in `hosts` is included. A `--host` that is not
   present in the config is an error.
 - The Secret's `.dockerconfigjson` holds one `auths` entry per host. A cloud


### PR DESCRIPTION
`flux-mirror secret` updates the Secret data, but it also drops existing labels and annotations. that's a bit rough for rotated pull creds.

Repro
1. Create a `kubernetes.io/dockerconfigjson` Secret.
2. Add a label or annotation to it.
3. Run `flux-mirror secret <name>` again for the same Secret.
4. Check the Secret. data is updated, metadata is gone.

Fix
- preserve existing labels and annotations on replace
- add a regression test
- note the behavior in `docs/guides/secret.md`
