### PR TITLE
fix: protect shared slice in EntriesAreSequential test

### DIFF
--- a/internal/sync/runner_test.go
+++ b/internal/sync/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -243,11 +244,16 @@ func TestRunner_EntriesAreSequential(t *testing.T) {
 	r := newRunner(t)
 	r.Concurrency = 4
 
-	var order []string
+	var (
+		mu    sync.Mutex
+		order []string
+	)
 	makeJob := func(label string) Job {
 		return Job{ID: label, Run: func(_ context.Context) (JobResult, error) {
 			time.Sleep(10 * time.Millisecond)
+			mu.Lock()
 			order = append(order, label)
+			mu.Unlock()
 			return JobResult{Status: StatusCopied}, nil
 		}}
 	}


### PR DESCRIPTION
TestRunner_EntriesAreSequential sets Concurrency=4, which means the two jobs in the first entry (a1, a2) run concurrently inside errgroup. Both goroutines write to the shared `order` slice with no synchronization, so `go test -race` catches this.

Reproduce:

```
go test -race ./internal/sync/... -run TestRunner_EntriesAreSequential
```

Fix: wrap the append in a mutex so concurrent writers don't stomp on each other. The test logic is unchanged - b1 still has to be the last element.