### PR TITLE
fix: validate sync flag values

### DIFF
--- a/cmd/flux-mirror/sync.go
+++ b/cmd/flux-mirror/sync.go
@@ -115,8 +115,9 @@ func init() {
 }
 
 func syncCmdRun(cmd *cobra.Command, args []string) error {
-	if syncArgs.driftExitCode < 0 || syncArgs.driftExitCode > syncMaxCustomDriftExitCode {
-		return fmt.Errorf("--drift-exit-code must be between 0 and %d", syncMaxCustomDriftExitCode)
+	timeout := resolveSyncTimeout(cmd)
+	if err := validateSyncArgs(timeout); err != nil {
+		return err
 	}
 
 	cfgPath, err := resolveConfigPath(args)
@@ -127,8 +128,6 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	timeout := resolveSyncTimeout(cmd)
 
 	// Verbose enables our own structured logs (sync started, entry started,
 	// mirroring tag, tag done, entry summary, sync complete) AND wires
@@ -237,6 +236,22 @@ func syncCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return classifyExit(res, syncArgs.driftExitCode)
+}
+
+func validateSyncArgs(timeout time.Duration) error {
+	if syncArgs.concurrency <= 0 {
+		return fmt.Errorf("--concurrency must be greater than 0")
+	}
+	if syncArgs.retries < 0 {
+		return fmt.Errorf("--retries must be greater than or equal to 0")
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("--timeout must be greater than 0")
+	}
+	if syncArgs.driftExitCode < 0 || syncArgs.driftExitCode > syncMaxCustomDriftExitCode {
+		return fmt.Errorf("--drift-exit-code must be between 0 and %d", syncMaxCustomDriftExitCode)
+	}
+	return nil
 }
 
 func resolveSyncTimeout(cmd *cobra.Command) time.Duration {

--- a/cmd/flux-mirror/sync_test.go
+++ b/cmd/flux-mirror/sync_test.go
@@ -388,6 +388,55 @@ func TestSync_DriftExitCodeValidation(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("--drift-exit-code must be between 0 and 255"))
 }
 
+func TestSync_FlagValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		setup     func(*testing.T)
+		wantError string
+	}{
+		{
+			name:      "rejects non-positive concurrency",
+			args:      []string{"sync", "config.yaml", "--concurrency", "0"},
+			wantError: "--concurrency must be greater than 0",
+		},
+		{
+			name:      "rejects negative retries",
+			args:      []string{"sync", "config.yaml", "--retries", "-1"},
+			wantError: "--retries must be greater than or equal to 0",
+		},
+		{
+			name:      "rejects non-positive sync timeout",
+			args:      []string{"sync", "config.yaml", "--timeout", "0s"},
+			wantError: "--timeout must be greater than 0",
+		},
+		{
+			name: "rejects non-positive inherited root timeout",
+			args: []string{"sync", "config.yaml"},
+			setup: func(t *testing.T) {
+				t.Helper()
+				_ = rootCmd.PersistentFlags().Set("timeout", "0s")
+			},
+			wantError: "--timeout must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			defer resetCmdArgs()
+
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			_, err := executeCommand(tt.args)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.wantError))
+		})
+	}
+}
+
 func TestSyncHelp_UsesEffectiveTimeoutDefault(t *testing.T) {
 	g := NewWithT(t)
 

--- a/docs/guides/sync.md
+++ b/docs/guides/sync.md
@@ -62,9 +62,9 @@ repository credentials automatically.
 | Flag                            | Default | Description                                                                                                                          |
 |---------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
 | `-o, --output text\|yaml\|json` | `text`  | Output format. `text` is human-friendly; `yaml` and `json` print the structured [sync report](../report/README.md) to stdout.       |
-| `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel per job.                                                                       |
-| `--retries N`                   | `3`     | Maximum number of retry attempts per job, within the `--timeout` budget.                                                            |
-| `--timeout DURATION`            | `5m`    | Per-job total budget covering all retry attempts.                                                                                   |
+| `--concurrency N`               | `4`     | Maximum number of copy operations to run in parallel per job. Must be greater than `0`.                                            |
+| `--retries N`                   | `3`     | Maximum number of retry attempts per job, within the `--timeout` budget. Must be greater than or equal to `0`.                     |
+| `--timeout DURATION`            | `5m`    | Per-job total budget covering all retry attempts. Must be greater than `0`.                                                         |
 | `--overwrite`                   | `false` | Force `overwrite: true` on every entry, regardless of per-entry config. See [Overwrite and drift behavior](../config/README.md#overwrite-and-drift-behavior). |
 | `--drift-exit-code N`           | `2`     | Exit code to use when drift is detected without failures (0–255). Set to `0` for immutable destinations that should not fail CI on drift. |
 | `--dry-run`                     | `false` | Run the plan and comparison pipeline without performing any writes. Reported as `would-copy` / `would-overwrite`.                   |


### PR DESCRIPTION
`sync` accepted bad runtime flags like `--concurrency=0`, `--retries=-1`, and `--timeout=0s`.
It then quietly fell back to defaults and kept going. Kinda sneaky, not great for users.

This makes `sync` fail fast with clear flag errors.
Also adds regression tests and updates the flag docs.

Repro:
1. Write a minimal config, for example:
```yaml
apiVersion: mirror.plugin.fluxcd.io/v1beta1
kind: Config
artifacts:
  - source: ghcr.io/stefanprodan/podinfo
    destination: example.invalid/test/podinfo
    selector:
      semver: ">=1.0.0"
      limit: 1
```
2. Run one of these:
`flux-mirror sync config.yaml --concurrency=-1 --dry-run --no-progress`
`flux-mirror sync config.yaml --retries=-5 --dry-run --no-progress`
`flux-mirror sync config.yaml --timeout=0s --dry-run --no-progress`
3. Before this patch, `sync` kept going and only failed later in registry or DNS work.
4. After this patch, it errors right away on the bad flag.
