### PR TITLE
test: add coverage for required-field validators

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,6 +295,14 @@ func TestValidate_Table(t *testing.T) {
 			errMsg: "limit must be >= 0",
 		},
 		{
+			name: "chart missing name",
+			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Charts: []ChartEntry{{
+				Source: "https://charts.example.com", Destination: "oci://ghcr.io/x",
+				Name: "",
+			}}},
+			errMsg: "name is required",
+		},
+		{
 			name: "artifact bad source",
 			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: []ArtifactEntry{{
 				Source: "not a repo!", Destination: "ghcr.io/c/d",
@@ -308,6 +316,14 @@ func TestValidate_Table(t *testing.T) {
 				Selector: Selector{Regex: &RegexFilter{Pattern: "(unclosed"}},
 			}}},
 			errMsg: "does not compile",
+		},
+		{
+			name: "selector empty regex pattern",
+			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: []ArtifactEntry{{
+				Source: "ghcr.io/a/b", Destination: "ghcr.io/c/d",
+				Selector: Selector{Regex: &RegexFilter{Pattern: ""}},
+			}}},
+			errMsg: "regex.pattern is required",
 		},
 		{
 			name: "selector bad semver",
@@ -361,6 +377,19 @@ func TestValidate_Table(t *testing.T) {
 				},
 			}}},
 			errMsg: "issuer is required",
+		},
+		{
+			name: "verify missing subject",
+			cfg: Config{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ConfigKind}, Artifacts: []ArtifactEntry{{
+				Source: "ghcr.io/a/b", Destination: "ghcr.io/c/d",
+				Verify: &ArtifactVerification{
+					Provider: VerifyProviderCosign,
+					MatchOIDCIdentity: []OIDCIdentity{{
+						Issuer: "https://token.actions.githubusercontent.com",
+					}},
+				},
+			}}},
+			errMsg: "subject is required",
 		},
 		{
 			name: "verify bad subject regex",


### PR DESCRIPTION
Three validation branches in `internal/config/config.go` have no test coverage at all. The logic is fine, just no cases hitting those paths in `TestValidate_Table`.

Missing cases:

- `charts[].name` empty -> should reject with "name is required"
- `selector.regex.pattern` empty (when `regex` block is present) -> "regex.pattern is required"
- `matchOIDCIdentity[i].subject` empty (issuer is set) -> "subject is required"

The `selector.regex` case is a bit sneaky — there's already a test for an *invalid* pattern (`"(unclosed"`), but nothing for the blank-pattern path, which is a separate branch.

How to repro before this fix (just run the table test and grep for what's missing):

```
go test ./internal/config/ -v -run TestValidate_Table 2>&1 | grep -E 'chart_missing|empty_regex|missing_subject'
# no output - those subtests don't exist yet
```

After the fix all three subtests show up and pass.

## Test plan

- [x] `go test ./internal/config/ -run TestValidate_Table` passes with the new cases
- [x] `go test ./...` clean