### PR TITLE
Reset secret kube flags between test runs

### DIFF
--- a/cmd/flux-mirror/main_test.go
+++ b/cmd/flux-mirror/main_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 var (
@@ -65,6 +67,7 @@ func resetCmdArgs() {
 	// bool flags in the command tree to their default state for test isolation;
 	// the command arg structs above handle the non-bool flag values.
 	resetFlags(rootCmd)
+	resetSecretKubeFlags()
 }
 
 func resetFlags(cmd *cobra.Command) {
@@ -82,4 +85,64 @@ func resetFlagSet(fs *pflag.FlagSet) {
 		}
 		f.Changed = false
 	})
+}
+
+func resetSecretKubeFlags() {
+	fresh := genericclioptions.NewConfigFlags(true)
+
+	resetStringPtr(secretKubeFlags.CacheDir, fresh.CacheDir)
+	resetStringPtr(secretKubeFlags.KubeConfig, fresh.KubeConfig)
+	resetStringPtr(secretKubeFlags.ClusterName, fresh.ClusterName)
+	resetStringPtr(secretKubeFlags.AuthInfoName, fresh.AuthInfoName)
+	resetStringPtr(secretKubeFlags.Context, fresh.Context)
+	resetStringPtr(secretKubeFlags.Namespace, fresh.Namespace)
+	resetStringPtr(secretKubeFlags.APIServer, fresh.APIServer)
+	resetStringPtr(secretKubeFlags.TLSServerName, fresh.TLSServerName)
+	resetBoolPtr(secretKubeFlags.Insecure, fresh.Insecure)
+	resetStringPtr(secretKubeFlags.CertFile, fresh.CertFile)
+	resetStringPtr(secretKubeFlags.KeyFile, fresh.KeyFile)
+	resetStringPtr(secretKubeFlags.CAFile, fresh.CAFile)
+	resetStringPtr(secretKubeFlags.BearerToken, fresh.BearerToken)
+	resetStringPtr(secretKubeFlags.Impersonate, fresh.Impersonate)
+	resetStringPtr(secretKubeFlags.ImpersonateUID, fresh.ImpersonateUID)
+	resetStringSlicePtr(secretKubeFlags.ImpersonateGroup, fresh.ImpersonateGroup)
+	resetStringSlicePtr(secretKubeFlags.ImpersonateUserExtra, fresh.ImpersonateUserExtra)
+	resetStringPtr(secretKubeFlags.Username, fresh.Username)
+	resetStringPtr(secretKubeFlags.Password, fresh.Password)
+	resetStringPtr(secretKubeFlags.Timeout, fresh.Timeout)
+	resetBoolPtr(secretKubeFlags.DisableCompression, fresh.DisableCompression)
+}
+
+func resetStringPtr(dst, src *string) {
+	if dst != nil && src != nil {
+		*dst = *src
+	}
+}
+
+func resetBoolPtr(dst, src *bool) {
+	if dst != nil && src != nil {
+		*dst = *src
+	}
+}
+
+func resetStringSlicePtr(dst, src *[]string) {
+	if dst != nil && src != nil {
+		*dst = append((*dst)[:0], (*src)...)
+	}
+}
+
+func TestResetCmdArgs_ResetsSecretKubeFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(secretCmd.Flags().Set("namespace", "flux-system")).To(Succeed())
+	g.Expect(secretCmd.Flags().Set("context", "prod")).To(Succeed())
+	g.Expect(secretCmd.Flags().Set("request-timeout", "45s")).To(Succeed())
+	g.Expect(secretCmd.Flags().Set("insecure-skip-tls-verify", "true")).To(Succeed())
+
+	resetCmdArgs()
+
+	g.Expect(secretCmd.Flags().Lookup("namespace").Value.String()).To(BeEmpty())
+	g.Expect(secretCmd.Flags().Lookup("context").Value.String()).To(BeEmpty())
+	g.Expect(secretCmd.Flags().Lookup("request-timeout").Value.String()).To(Equal("0"))
+	g.Expect(secretCmd.Flags().Lookup("insecure-skip-tls-verify").Value.String()).To(Equal("false"))
 }


### PR DESCRIPTION
`create secret` tests had kinda sticky kubectl flag state. `resetCmdArgs()` cleared cobra flags, but the shared `ConfigFlags` still kept values like `--namespace`, `--context`, `--request-timeout`, and TLS settings, so the next test could inherit old state. This resets those fields too and adds a regression test.

Repro on `main`:
1. Set `secretCmd.Flags().Set("namespace", "flux-system")`
2. Call `resetCmdArgs()`
3. `secretCmd.Flags().Lookup("namespace").Value.String()` still returns `flux-system`, so the reset is busted.

Checked with `make test` and `make lint`.