### PR TITLE
Honor root timeout in login and secret

### DIFF
--- a/cmd/flux-mirror/login.go
+++ b/cmd/flux-mirror/login.go
@@ -75,6 +75,12 @@ func loginCmdRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	ctx, cancel, err := commandContextWithRootTimeout(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
 	// dockercfg.Load("") falls back to Docker's own config discovery
 	// ($DOCKER_CONFIG, else ~/.docker); a non-empty dir overrides it, matching
 	// 'docker --config <dir>'.
@@ -98,7 +104,7 @@ func loginCmdRun(cmd *cobra.Command, _ []string) error {
 			cmd.Printf("• skipping %s: no credential configured (TLS-only host)\n", h.Host)
 			continue
 		}
-		ha, err := registryauth.ResolveHostAuth(cmd.Context(), h)
+		ha, err := resolveHostAuth(ctx, h)
 		if err != nil {
 			return fmt.Errorf("host %q: %w", h.Host, err)
 		}

--- a/cmd/flux-mirror/login_test.go
+++ b/cmd/flux-mirror/login_test.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	apiv1 "github.com/fluxcd/flux-mirror/api/v1beta1"
+	"github.com/fluxcd/flux-mirror/internal/registryauth"
 	gojwt "github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/gomega"
 )
@@ -407,4 +411,42 @@ hosts:
 	out, err := executeCommand([]string{"login", "--config", path, "--docker-config", dockerDir, "--plaintext"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(out).To(ContainSubstring("skipping tls.example.com"))
+}
+
+func TestLogin_RejectsNonPositiveRootTimeout(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
+	cfg := writeLoginConfig(t)
+
+	_, err := executeCommand([]string{"--timeout", "0s", "login", "--config", cfg})
+	g.Expect(err).To(MatchError("--timeout must be greater than 0"))
+}
+
+func TestLogin_RootTimeoutCancelsCredentialResolution(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("MY_LOGIN_TOKEN", "static-token-value")
+	cfg := writeLoginConfig(t)
+
+	oldResolveHostAuth := resolveHostAuth
+	resolveHostAuth = func(ctx context.Context, _ apiv1.RegistryHost) (registryauth.HostAuth, error) {
+		select {
+		case <-ctx.Done():
+			return registryauth.HostAuth{}, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+			return registryauth.HostAuth{}, errors.New("credential resolution was not canceled by --timeout")
+		}
+	}
+	defer func() {
+		resolveHostAuth = oldResolveHostAuth
+	}()
+
+	_, err := executeCommand([]string{
+		"--timeout", "1ms",
+		"login",
+		"--host", "registry.example.com",
+		"--config", cfg,
+		"--docker-config", t.TempDir(),
+		"--plaintext",
+	})
+	g.Expect(err).To(MatchError(ContainSubstring("context deadline exceeded")))
 }

--- a/cmd/flux-mirror/main.go
+++ b/cmd/flux-mirror/main.go
@@ -6,12 +6,15 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/fluxcd/flux-mirror/internal/registryauth"
 )
 
 var (
@@ -39,6 +42,8 @@ var rootArgs = rootFlags{
 	timeout: time.Minute,
 }
 
+var resolveHostAuth = registryauth.ResolveHostAuth
+
 func init() {
 	rootCmd.PersistentFlags().DurationVar(&rootArgs.timeout, "timeout", rootArgs.timeout,
 		"The length of time to wait before giving up on the current operation.")
@@ -46,6 +51,14 @@ func init() {
 		"Disable environment variable substitution in config files.")
 
 	rootCmd.SetOut(os.Stdout)
+}
+
+func commandContextWithRootTimeout(cmd *cobra.Command) (context.Context, context.CancelFunc, error) {
+	if rootArgs.timeout <= 0 {
+		return nil, nil, fmt.Errorf("--timeout must be greater than 0")
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	return ctx, cancel, nil
 }
 
 // exitCoder lets a command return a non-default exit code (e.g. sync's

--- a/cmd/flux-mirror/secret.go
+++ b/cmd/flux-mirror/secret.go
@@ -83,6 +83,12 @@ func secretCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	ctx, cancel, err := commandContextWithRootTimeout(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
 	// Resolve cluster + namespace before minting credentials so a broken
 	// kubeconfig fails fast.
 	ns, _, err := secretKubeFlags.ToRawKubeConfigLoader().Namespace()
@@ -106,7 +112,7 @@ func secretCmdRun(cmd *cobra.Command, args []string) error {
 			cmd.Printf("• skipping %s: no credential configured (TLS-only host)\n", h.Host)
 			continue
 		}
-		ha, err := registryauth.ResolveHostAuth(cmd.Context(), h)
+		ha, err := resolveHostAuth(ctx, h)
 		if err != nil {
 			return fmt.Errorf("host %q: %w", h.Host, err)
 		}
@@ -117,7 +123,7 @@ func secretCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	created, err := applySecret(cmd.Context(), clientset, secret, secretArgs.create)
+	created, err := applySecret(ctx, clientset, secret, secretArgs.create)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
What
`login` and `secret` say they honor the global `--timeout`, but they didnt.
They passed `cmd.Context()` through as-is, so provider-backed auth could just sit there and ignore the deadline.

This wires the root timeout into both commands and adds regression tests.

Repro
1. Use a host that mints creds over network, like `provider: ecr`.
2. Run `flux-mirror --timeout=1ms login -f hosts.yaml`
3. Before this patch it can keep waiting on auth. After this patch it fails fast with `context deadline exceeded`.

Assisted-by: codex/gpt-5
